### PR TITLE
Quick fix to allow CairoSVG to run under CYGWIN with python 2.6

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -68,7 +68,10 @@ def remove_svg_namespace(tree):
     """
     prefix = "{http://www.w3.org/2000/svg}"
     prefix_len = len(prefix)
-    for element in tree.iter():
+    iterator = (
+        tree.iter() if hasattr(tree, 'iter')
+        else tree.getiterator())
+    for element in iterator:
         tag = element.tag
         if hasattr(tag, "startswith") and tag.startswith(prefix):
             element.tag = tag[prefix_len:]


### PR DESCRIPTION
Hello,

Trying to run CairoSVG under Cygwin with Python 2.6, I came across an issue in cairosvg/parser.py:remove_svg_namespace(), which referenced the not available "iter()" function.

Since a similar workaround was already present in this file (use getiterator() then), I fixed the code the same way.

Thx
