### PR TITLE
Cairosvg crashes if node.attrib.get("systemLanguage", LOCALE) is None

### DIFF
--- a/cairosvg/features.py
+++ b/cairosvg/features.py
@@ -57,6 +57,9 @@ def has_features(features):
 
 def support_languages(languages):
     """Check whether one of ``languages`` is part of the user locales."""
+    if languages is None:
+        return True
+    
     for language in languages.split(","):
         language = language.strip()
         if language and LOCALE.startswith(language):


### PR DESCRIPTION
This might just be hiding an underlying problem, but if there is
no locality and the LOCALE isn't defined for whatever reason, just return True instead of crashing.
