### PR TITLE
Switch to tinycss2 and cssselect2, support CSS without lxml.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,8 @@ deps=
     nose
     nose-cov
     pillow
-    lxml
-    tinycss
-    cssselect
+    tinycss2
+;    cssselect2
     cairocffi
 commands=nosetests []
 sitepackages=True


### PR DESCRIPTION
**Do not merge yet.**

cssselect2 is not on PyPI yet. Test with git+https://github.com/SimonSapin/cssselect2

I have 74 CairoSVG test failures locally. Those I looked at are all due to differences in text rendering. There may still be bugs, please review.

In particular, I’m not quite what should happen whith `Node(…, parent_children=True)`

Because selector matching in cssselect2 operates on an `ElementWrapper` object (to work around the lack of `getparent()` API in ElementTree), `Node` now takes that as a first parameter instead of an ElementTree `Element`. For this reason, and because cssselect2, tinycss2 and webencodings (used by tinycss2) are all pure Python, maintaining a separate code path to make CSS support (and the dependencies) optional is not worth it IMO.

Also, ElementTree out of the box does not parse XML processing instructions, so external stylesheet support (`<?xml-stylesheet href="…" ?>`) has regressed.

`setup.py` still needs to be changed to list the dependencies, and thus switched to setuptools rather than distutils.
