### PR TITLE
Fall back to pycairo if cairocffi is unable to find the cairo library

### DIFF
--- a/cairosvg/surface/__init__.py
+++ b/cairosvg/surface/__init__.py
@@ -23,7 +23,7 @@ Cairo surface creators.
 import io
 try:
     import cairocffi as cairo
-except ImportError:
+except (ImportError, OSError):
     import cairo  # pycairo
 
 from ..parser import Tree


### PR DESCRIPTION
Since 1.0.5 pip automatically installs cairocffi.
I already have a working pycairo, that includes _cairo.pyd, but not libcairo-2.dll.
This causes the import to fail.
