### PR TITLE
Fix scaling with negative viewBox origin.

### DIFF
--- a/cairosvg/surface/__init__.py
+++ b/cairosvg/surface/__init__.py
@@ -173,11 +173,11 @@ class Surface(object):
             if x_ratio > y_ratio:
                 matrix.translate((width - x_size * y_ratio) / 2, 0)
                 matrix.scale(y_ratio, y_ratio)
-                matrix.translate(-x, -y / y_ratio * x_ratio)
+                matrix.translate(-x / x_ratio * y_ratio, -y)
             elif x_ratio < y_ratio:
                 matrix.translate(0, (height - y_size * x_ratio) / 2)
                 matrix.scale(x_ratio, x_ratio)
-                matrix.translate(-x / x_ratio * y_ratio, -y)
+                matrix.translate(-x, -y / y_ratio * x_ratio)
             else:
                 matrix.scale(x_ratio, y_ratio)
                 matrix.translate(-x, -y)


### PR DESCRIPTION
This fixes translation problems when trying to scale an SVG via its width and height attributes when the viewbox's origin is negative.

Here are a couple of example SVG's:

http://www.thenounproject.com.s3.amazonaws.com/img/wide.svg
http://www.thenounproject.com.s3.amazonaws.com/img/tall.svg

And the relevant cairo commands:

`cairosvg wide.svg -f png -o wide.png`
`cairosvg tall.svg -f png -o tall.png`
