### PR TITLE
removed the forced ratio in PNGSurface

### DIFF
--- a/cairosvg/surface/__init__.py
+++ b/cairosvg/surface/__init__.py
@@ -406,7 +406,7 @@ class PSSurface(MultipageSurface):
 
 class PNGSurface(Surface):
     """A surface that writes in PNG format."""
-    device_units_per_user_units = 1
+    # device_units_per_user_units = 1
 
     def _create_surface(self, width, height):
         """Create and return ``(cairo_surface, width, height)``."""


### PR DESCRIPTION
PngSurface had a ratio forced to 1. This made the dpi parameter useless when using PNGSurface.
