### PR TITLE
Use cairo show_text for the simple text rendering case

### DIFF
--- a/cairosvg/surface/__init__.py
+++ b/cairosvg/surface/__init__.py
@@ -123,6 +123,8 @@ class Surface(object):
         self.cursor_position = [0, 0]
         self.cursor_d_position = [0, 0]
         self.text_path_width = 0
+        self.simple_text = True
+        self.text_position = None
         self.tree_cache = {(tree.url, tree["id"]): tree}
         if parent_surface:
             self.markers = parent_surface.markers
@@ -361,7 +363,14 @@ class Surface(object):
                 if node.get("fill-rule") == "evenodd":
                     self.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
-            self.context.fill_preserve()
+
+            if TAGS[node.tag] is TAGS["text"] \
+                    and self.simple_text \
+                    and self.text_position:
+                self.context.move_to(*self.context.device_to_user(*self.text_position))
+                self.context.show_text(node.text)
+            else:
+                self.context.fill_preserve()
             self.context.restore()
 
             # Stroke
@@ -399,6 +408,8 @@ class Surface(object):
             self.cursor_position = [0, 0]
             self.cursor_d_position = [0, 0]
             self.text_path_width = 0
+            self.simple_text = True
+            self.text_position = None
 
         if not node.root:
             # Restoring context is useless if we are in the root tag, it may


### PR DESCRIPTION
Added some code to detect when text rendering can be done using show_text instead of filling and stroking. I use CairoSVG to create multi page PDFs with lots of text, and for one of my cases the PDF shrank from 70M to 250k using this patch. And as an added bonus, the user may select and copy text in a PDF viewer.

I'm not sure that this is the most clever way to do it, I have not studied the code base extensively.
