### PR TITLE
Fixed bbox for polyline

### DIFF
--- a/cairosvg/bounding_box.py
+++ b/cairosvg/bounding_box.py
@@ -85,7 +85,7 @@ def bounding_box_polyline(surface, node):
     bounding_box = EMPTY_BOUNDING_BOX
     points = []
     normalized_points = normalize(node.get('points', ''))
-    while points:
+    while normalized_points:
         x, y, normalized_points = point(surface, normalized_points)
         points.append((x, y))
     return extend_bounding_box(bounding_box, points)


### PR DESCRIPTION
Small bug in getting the bounding box for a polyline. Does not show with current testset (no gradient patterns in there).

Attached is an example file to demonstrate bug.
[fix_bbox_polyline.zip](https://github.com/Kozea/CairoSVG/files/250198/fix_bbox_polyline.zip)
