### PR TITLE
Case sensitivity for style declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 .noseids
 .cache
+.idea

--- a/cairosvg/bounding_box.py
+++ b/cairosvg/bounding_box.py
@@ -85,7 +85,7 @@ def bounding_box_polyline(surface, node):
     bounding_box = EMPTY_BOUNDING_BOX
     points = []
     normalized_points = normalize(node.get('points', ''))
-    while points:
+    while normalized_points:
         x, y, normalized_points = point(surface, normalized_points)
         points.append((x, y))
     return extend_bounding_box(bounding_box, points)

--- a/cairosvg/bounding_box.py
+++ b/cairosvg/bounding_box.py
@@ -133,10 +133,12 @@ def bounding_box_path(surface, node):
                 x += previous_x
                 y += previous_y
 
-            # Only extend bounding box with end coordinate
+            # Extend bounding box with start and end coordinates
             arc_bounding_box = bounding_box_elliptical_arc(
                 previous_x, previous_y, rx, ry, rotation, large, sweep, x, y)
-            points = (arc_bounding_box[0:2], arc_bounding_box[2:])
+            points = (arc_bounding_box[0:2],
+                      tuple(sum(value) for value in
+                            zip(arc_bounding_box[0:2], arc_bounding_box[2:])))
             bounding_box = extend_bounding_box(bounding_box, points)
             previous_x = x
             previous_y = y
@@ -246,7 +248,7 @@ def bounding_box_elliptical_arc(x1, y1, rx, ry, phi, large, sweep, x, y):
     """
     rx, ry = abs(rx), abs(ry)
     if rx == 0 or ry == 0:
-        return min(x, x1), min(y, y1), max(x, x1), max(y, y1)
+        return min(x, x1), min(y, y1), abs(x - x1), abs(y - y1)
 
     x1prime = cos(phi) * (x1 - x) / 2 + sin(phi) * (y1 - y) / 2
     y1prime = -sin(phi) * (x1 - x) / 2 + cos(phi) * (y1 - y) / 2
@@ -260,7 +262,7 @@ def bounding_box_elliptical_arc(x1, y1, rx, ry, phi, large, sweep, x, y):
         ratio = rx / ry
         radicant = y1prime ** 2 + x1prime ** 2 / ratio ** 2
         if radicant < 0:
-            return min(x, x1), min(y, y1), max(x, x1), max(y, y1)
+            return min(x, x1), min(y, y1), abs(x - x1), abs(y - y1)
         ry = sqrt(radicant)
         rx = ratio * ry
     else:

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -209,17 +209,21 @@ def draw_gradient(surface, node, name):
         fy = size(surface, gradient_node.get('fy', str(cy)), height_ref)
         gradient_pattern = cairo.RadialGradient(fx, fy, 0, cx, cy, r)
 
-    # Apply transform of gradient
-    transform(surface, gradient_node.get('gradientTransform'))
-
     # Apply matrix to set coordinate system for gradient
+    onGradient = False
     if gradient_node.get('gradientUnits') != 'userSpaceOnUse':
+        onGradient = True
         gradient_pattern.set_matrix(cairo.Matrix(
             1 / width, 0, 0, 1 / height, - x / width, - y / height))
 
+    # Apply transform of gradient
+    transform(surface, gradient_node.get('gradientTransform'), gradient_pattern if onGradient else None)
+
     # Set spread method for gradient outside target bounds
+    """
     gradient_pattern.set_extend(EXTEND_OPERATORS.get(
         node.get('spreadMethod', 'pad'), EXTEND_OPERATORS['pad']))
+    """
 
     # Apply gradient (<stop> by <stop>)
     offset = 0
@@ -235,6 +239,7 @@ def draw_gradient(surface, node, name):
         gradient_node.get('spreadMethod', 'pad'), EXTEND_OPERATORS['pad']))
 
     surface.context.set_source(gradient_pattern)
+    # Test if applying matrix/transform here works (for gradient_pattern)
     return True
 
 

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -212,10 +212,14 @@ def draw_gradient(surface, node, name):
             1 / width, 0, 0, 1 / height, - x / width, - y / height))
 
     # Apply transform of gradient
-    transform(surface, gradient_node.get('gradientTransform'), gradient_pattern if onGradient else None)
+    transform(surface,
+              gradient_node.get('gradientTransform'),
+              gradient_pattern if onGradient else None)
 
     # Set spread method for gradient outside target bounds
     """
+    # This does not seem to do anything.
+    # Is there a test showing its functionality?
     gradient_pattern.set_extend(EXTEND_OPERATORS.get(
         node.get('spreadMethod', 'pad'), EXTEND_OPERATORS['pad']))
     """
@@ -234,7 +238,6 @@ def draw_gradient(surface, node, name):
         gradient_node.get('spreadMethod', 'pad'), EXTEND_OPERATORS['pad']))
 
     surface.context.set_source(gradient_pattern)
-    # Test if applying matrix/transform here works (for gradient_pattern)
     return True
 
 

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -205,16 +205,16 @@ def draw_gradient(surface, node, name):
         gradient_pattern = cairo.RadialGradient(fx, fy, 0, cx, cy, r)
 
     # Apply matrix to set coordinate system for gradient
-    onGradient = False
+    apply_matrix_on_gradient = False
     if gradient_node.get('gradientUnits') != 'userSpaceOnUse':
-        onGradient = True
+        apply_matrix_on_gradient = True
         gradient_pattern.set_matrix(cairo.Matrix(
             1 / width, 0, 0, 1 / height, - x / width, - y / height))
 
     # Apply transform of gradient
     transform(surface,
               gradient_node.get('gradientTransform'),
-              gradient_pattern if onGradient else None)
+              gradient_pattern if apply_matrix_on_gradient else None)
 
     # Set spread method for gradient outside target bounds
     """

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -205,16 +205,14 @@ def draw_gradient(surface, node, name):
         gradient_pattern = cairo.RadialGradient(fx, fy, 0, cx, cy, r)
 
     # Apply matrix to set coordinate system for gradient
-    apply_matrix_on_gradient = False
     if gradient_node.get('gradientUnits') != 'userSpaceOnUse':
-        apply_matrix_on_gradient = True
         gradient_pattern.set_matrix(cairo.Matrix(
             1 / width, 0, 0, 1 / height, - x / width, - y / height))
 
     # Apply transform of gradient
     transform(surface,
               gradient_node.get('gradientTransform'),
-              gradient_pattern if apply_matrix_on_gradient else None)
+              gradient_pattern)
 
     # Set spread method for gradient outside target bounds
     """

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -242,7 +242,7 @@ def apply_matrix_transform(surface, matrix, gradient = None):
         matrix.invert()
         if gradient:
             matrix_now = gradient.get_matrix()
-            gradient.set_matrix(matrix_now.multiply(matrix))
+            gradient.set_matrix(matrix.multiply(matrix_now))
         else:
             surface.context.transform(matrix)
 

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -239,11 +239,13 @@ def apply_matrix_transform(surface, matrix, gradient = None):
         surface.context.clip()
         surface.context.append_path(active_path)
     else:
-        matrix.invert()
         if gradient:
+            # When applied on gradient use already inverted matrix (mapping
+            # from user space to gradient space)
             matrix_now = gradient.get_matrix()
-            gradient.set_matrix(matrix.multiply(matrix_now))
+            gradient.set_matrix(matrix_now.multiply(matrix))
         else:
+            matrix.invert()
             surface.context.transform(matrix)
 
 

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -183,7 +183,7 @@ def rotate(x, y, angle):
     return x * cos(angle) - y * sin(angle), y * cos(angle) + x * sin(angle)
 
 
-def transform(surface, string):
+def transform(surface, string, gradient = None):
     """Update ``surface`` matrix according to transformation ``string``.
 
     See http://www.w3.org/TR/SVG/coords.html#TransformAttribute
@@ -218,10 +218,10 @@ def transform(surface, string):
             if len(values) == 1:
                 values = 2 * values
             matrix.scale(*values)
-    apply_matrix_transform(surface, matrix)
+    apply_matrix_transform(surface, matrix, gradient)
 
 
-def apply_matrix_transform(surface, matrix):
+def apply_matrix_transform(surface, matrix, gradient = None):
     """Apply a ``matrix`` to ``surface``.
 
     When the matrix is not invertible, this function clips the context to an
@@ -238,7 +238,11 @@ def apply_matrix_transform(surface, matrix):
         surface.context.append_path(active_path)
     else:
         matrix.invert()
-        surface.context.transform(matrix)
+        if gradient:
+            matrixNow = gradient.get_matrix()
+            gradient.set_matrix(matrixNow.multiply(matrix))
+        else:
+            surface.context.transform(matrix)
 
 
 def clip_rect(string):

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -185,7 +185,8 @@ def rotate(x, y, angle):
 
 
 def transform(surface, string, gradient = None):
-    """Update ``surface`` matrix according to transformation ``string``.
+    """Update ``surface`` or ``gradient`` (if supplied)
+       according to transformation ``string``.
 
     See http://www.w3.org/TR/SVG/coords.html#TransformAttribute
 
@@ -223,7 +224,7 @@ def transform(surface, string, gradient = None):
 
 
 def apply_matrix_transform(surface, matrix, gradient = None):
-    """Apply a ``matrix`` to ``surface``.
+    """Apply a ``matrix`` to ``surface`` or ``gradient`` if supplied.
 
     When the matrix is not invertible, this function clips the context to an
     empty path instead of raising an exception.
@@ -240,8 +241,8 @@ def apply_matrix_transform(surface, matrix, gradient = None):
     else:
         matrix.invert()
         if gradient:
-            matrixNow = gradient.get_matrix()
-            gradient.set_matrix(matrixNow.multiply(matrix))
+            matrix_now = gradient.get_matrix()
+            gradient.set_matrix(matrix_now.multiply(matrix))
         else:
             surface.context.transform(matrix)
 


### PR DESCRIPTION
Guillaume,

I have added a fix for the case sensitivity of style declarations.

In short, all declarations are still made lowercase (making them case insensitive), **except for**:
- id's
- classes
- font-names (defined through font and through font-family)
- url's (optional part of many declarations like stroke/paint/filter/mask/marker-start/...)

All style names are made lowercase.

Cheers,
Erik
