### PR TITLE
Add --scale parameter

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -71,6 +71,9 @@ def main():
         '-H', '--height', default=None, type=float,
         help='height of the parent container in pixels')
     parser.add_argument(
+        '-s', '--scale', default=None, type=float,
+        help='output scaling factor')
+    parser.add_argument(
         '-u', '--unsafe', action='store_true',
         help='resolve XML entities (WARNING: vulnerable to XXE attacks)')
     parser.add_argument('-o', '--output', default='-', help='output filename')
@@ -78,7 +81,7 @@ def main():
     options = parser.parse_args()
     kwargs = {
         'parent_width': options.width, 'parent_height': options.height,
-        'dpi': options.dpi, 'unsafe': options.unsafe}
+        'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe}
     kwargs['write_to'] = (
         sys.stdout.buffer if options.output == '-' else options.output)
     if options.input == '-':

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -130,16 +130,17 @@ class Surface(object):
         dpi = kwargs.pop('dpi', 96)
         parent_width = kwargs.pop('parent_width', None)
         parent_height = kwargs.pop('parent_height', None)
+        scale = kwargs.pop('scale', 1)
         write_to = kwargs.pop('write_to', None)
         kwargs['bytestring'] = bytestring
         tree = Tree(**kwargs)
         output = write_to or io.BytesIO()
-        cls(tree, output, dpi, None, parent_width, parent_height).finish()
+        cls(tree, output, dpi, None, parent_width, parent_height, scale).finish()
         if write_to is None:
             return output.getvalue()
 
     def __init__(self, tree, output, dpi, parent_surface=None,
-                 parent_width=None, parent_height=None):
+                 parent_width=None, parent_height=None, scale=1):
         """Create the surface from a filename or a file-like object.
 
         The rendered content is written to ``output`` which can be a filename,
@@ -176,6 +177,8 @@ class Surface(object):
         self.font_size = size(self, '12pt')
         self.stroke_and_fill = True
         width, height, viewbox = node_format(self, tree)
+        width *= scale
+        height *= scale
         # Actual surface dimensions: may be rounded on raster surfaces types
         self.cairo, self.width, self.height = self._create_surface(
             width * self.device_units_per_user_units,


### PR DESCRIPTION
As seen in #83.

Adds the `-s | --scale [N]` parameter to scale output dimensions by `N`.