### PR TITLE
Allow large SVG files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 .noseids
 .cache
+build

--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -72,7 +72,7 @@ def main():
         help='height of the parent container in pixels')
     parser.add_argument(
         '-u', '--unsafe', action='store_true',
-        help='resolve XML entities (WARNING: vulnerable to XXE attacks)')
+        help='resolve XML entities and allow very large files (WARNING: vulnerable to XXE attacks)')
     parser.add_argument('-o', '--output', default='-', help='output filename')
 
     options = parser.parse_args()

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -274,7 +274,7 @@ class Tree(Node):
             bytestring = bytestring or read_url(parse_url(self.url))
             if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
                 bytestring = gzip.decompress(bytestring)
-            parser = ElementTree.XMLParser(resolve_entities=unsafe)
+            parser = ElementTree.XMLParser(resolve_entities=unsafe, huge_tree=unsafe)
             tree = ElementTree.fromstring(bytestring, parser)
         remove_svg_namespace(tree)
         self.xml_tree = tree


### PR DESCRIPTION
This change allows svg2png to parse "large" SVG files. I believe that this limit varies system-by-system, but it was causing problems for me on Ubuntu with files larger than 9.5mb. Before this change, parsing a large file resulted in:
```
lxml.etree.XMLSyntaxError: internal error: Huge input lookup
```