### PR TITLE
Fixed scaling and clipping of markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 .noseids
 .cache
+/.idea

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -67,7 +67,7 @@ def image(surface, node):
             tree_height = tree['height'] = height
         node.image_width = tree_width or width
         node.image_height = tree_height or height
-        scale_x, scale_y, translate_x, translate_y = preserve_ratio(
+        scale_x, scale_y, translate_x, translate_y, _ = preserve_ratio(
             surface, node)
         surface.set_context_size(
             *node_format(surface, tree, reference=False),
@@ -87,7 +87,8 @@ def image(surface, node):
 
     node.image_width = image_surface.get_width()
     node.image_height = image_surface.get_height()
-    scale_x, scale_y, translate_x, translate_y = preserve_ratio(surface, node)
+    scale_x, scale_y, translate_x, translate_y, _ = preserve_ratio(
+        surface, node)
 
     surface.context.rectangle(x, y, width, height)
     pattern_pattern = cairo.SurfacePattern(image_surface)

--- a/cairosvg/svg.py
+++ b/cairosvg/svg.py
@@ -37,7 +37,8 @@ def svg(surface, node):
     if node.parent is None:
         return
 
-    scale_x, scale_y, translate_x, translate_y = preserve_ratio(surface, node)
+    scale_x, scale_y, translate_x, translate_y, _ = preserve_ratio(
+        surface, node)
     rect_width, rect_height = width, height
     surface.context.translate(*surface.context.get_current_point())
     if node.get('overflow', 'hidden') != 'visible':


### PR DESCRIPTION
Fixed that markers are scaled and clipped properly.
Reused some of the existing code for preserving aspect ratio, but had to tweak it as well. (Same as in the fix for gradient patterns, let me know if you feel this requires refactoring.)

Two existing tests will fail (but actually work ;-):
- marker.svg - actually it was not scaled correct in the original (fixed now)
- painting-marker-03-f.svg - difficult to see what actually changed (seems okay)

Two additional tests are now okay:
- fail/marker/painting-marker-02-f.svg (property inheritance)
- fail/marker/painting-marker-05-f.svg (visibility, ie clipping)

There are still some issues with two other 'marker' tests. These are the result of the way attributes and properties are handled. Changing/fixing this will require a bit more work, but it is unclear whether it really is necessary.

Cheers,
Erik