### PR TITLE
Add URLFetcher

### DIFF
--- a/cairosvg/bounding_box.py
+++ b/cairosvg/bounding_box.py
@@ -358,7 +358,7 @@ def bounding_box_group(surface, node):
 def bounding_box_use(surface, node):
     """Get the bounding box of a ``use`` node."""
     href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
-    tree = Tree(url=href, parent=node)
+    tree = Tree(url=href, url_fetcher=node.get_url_fetcher(), parent=node)
     if not match_features(tree.xml_tree):
         return None
     return calculate_bounding_box(surface, tree)

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -55,8 +55,8 @@ def update_def_href(surface, def_name, def_dict):
         update_def_href(surface, href, def_dict)
         href_node = def_dict[href]
         def_dict[def_name] = Tree(
-            url='#{}'.format(def_name), parent=href_node,
-            parent_children=(not def_node.children),
+            url='#{}'.format(def_name), url_fetcher=def_node.get_url_fetcher(),
+            parent=href_node, parent_children=(not def_node.children),
             tree_cache=surface.tree_cache)
         # Inherit attributes generally not inherited
         for key, value in href_node.items():
@@ -360,7 +360,8 @@ def use(surface, node):
     if 'mask' in node:
         del node['mask']
     href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
-    tree = Tree(url=href, parent=node, tree_cache=surface.tree_cache)
+    tree = Tree(url=href, url_fetcher=node.get_url_fetcher_for(href),
+                parent=node, tree_cache=surface.tree_cache)
 
     if not match_features(tree.xml_tree):
         surface.context.restore()

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -360,8 +360,9 @@ def use(surface, node):
     if 'mask' in node:
         del node['mask']
     href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
-    tree = Tree(url=href, url_fetcher=node.get_url_fetcher_for(href),
-                parent=node, tree_cache=surface.tree_cache)
+    tree = Tree(
+        url=href, url_fetcher=node.get_url_fetcher_for(href), parent=node,
+        tree_cache=surface.tree_cache)
 
     if not match_features(tree.xml_tree):
         surface.context.restore()

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -27,7 +27,7 @@ from PIL import Image
 from .helpers import node_format, preserve_ratio, preserved_ratio, size
 from .parser import Tree
 from .surface import cairo
-from .url import parse_url, read_url
+from .url import parse_url
 
 
 def image(surface, node):

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -34,9 +34,9 @@ def image(surface, node):
     """Draw an image ``node``."""
     base_url = node.get('{http://www.w3.org/XML/1998/namespace}base')
     if not base_url and node.url:
-        base_url = os.path.dirname(node.url)
+        base_url = os.path.dirname(node.url) + '/'
     url = parse_url(node.get('{http://www.w3.org/1999/xlink}href'), base_url)
-    image_bytes = read_url(url)
+    image_bytes = node.fetch_url(url)
 
     if len(image_bytes) < 5:
         return
@@ -54,8 +54,8 @@ def image(surface, node):
         if 'y' in node:
             del node['y']
         tree = Tree(
-            url=url.geturl(), bytestring=image_bytes,
-            tree_cache=surface.tree_cache)
+            url=url.geturl(), url_fetcher=node.get_url_fetcher(),
+            bytestring=image_bytes, tree_cache=surface.tree_cache)
         tree_width, tree_height, viewbox = node_format(
             surface, tree, reference=False)
         if not viewbox:

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -253,7 +253,7 @@ class Node(dict):
         return url_fetcher.fetcher_for(url) \
             if url_fetcher is not None else None
 
-    def fetch_url(self, url, get_child_fetcher = True):
+    def fetch_url(self, url, get_child_fetcher=True):
         return read_url(url, self.get_url_fetcher_for(url) if get_child_fetcher
                         else self.get_url_fetcher())
 
@@ -374,7 +374,7 @@ class Tree(Node):
             tree = root_parent.xml_tree
         else:
             bytestring = bytestring or \
-                         self.fetch_url(parse_url(self.url), False)
+                self.fetch_url(parse_url(self.url), False)
             if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
                 bytestring = gzip.decompress(bytestring)
             parser = ElementTree.XMLParser(

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -250,12 +250,12 @@ class Node(dict):
 
     def get_url_fetcher_for(self, url):
         url_fetcher = self.get_url_fetcher()
-        return url_fetcher.fetcher_for(url) \
-            if url_fetcher is not None else None
+        return None if url_fetcher is None else url_fetcher.fetcher_for(url)
 
     def fetch_url(self, url, get_child_fetcher=True):
-        return read_url(url, self.get_url_fetcher_for(url) if get_child_fetcher
-                        else self.get_url_fetcher())
+        return read_url(
+            url, self.get_url_fetcher_for(url) if get_child_fetcher
+            else self.get_url_fetcher())
 
     def text_children(self, node, trailing_space, text_root=False):
         """Create children and return them."""
@@ -275,9 +275,9 @@ class Node(dict):
             if child.tag == 'tref':
                 url = parse_url(child.get(
                     '{http://www.w3.org/1999/xlink}href')).geturl()
-                child_tree = Tree(url=url,
-                                  url_fetcher=self.get_url_fetcher_for(url),
-                                  parent=self)
+                child_tree = Tree(
+                    url=url, url_fetcher=self.get_url_fetcher_for(url),
+                    parent=self)
                 child_tree.clear()
                 child_tree.update(self)
                 child_node = Node(
@@ -373,8 +373,8 @@ class Tree(Node):
                 root_parent = root_parent.parent
             tree = root_parent.xml_tree
         else:
-            bytestring = bytestring or \
-                self.fetch_url(parse_url(self.url), False)
+            if not bytestring:
+                bytestring = self.fetch_url(parse_url(self.url), False)
             if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
                 bytestring = gzip.decompress(bytestring)
             parser = ElementTree.XMLParser(

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -241,6 +241,22 @@ class Node(dict):
                         if self.tag == 'switch':
                             break
 
+    def get_url_fetcher(self):
+        if getattr(self, 'url_fetcher', None) is not None:
+            return self.url_fetcher
+        if getattr(self, 'parent', None) is not None:
+            return self.parent.get_url_fetcher()
+        return None
+
+    def get_url_fetcher_for(self, url):
+        url_fetcher = self.get_url_fetcher()
+        return url_fetcher.fetcher_for(url) \
+            if url_fetcher is not None else None
+
+    def fetch_url(self, url, get_child_fetcher = True):
+        return read_url(url, self.get_url_fetcher_for(url) if get_child_fetcher
+                        else self.get_url_fetcher())
+
     def text_children(self, node, trailing_space, text_root=False):
         """Create children and return them."""
         children = []
@@ -259,7 +275,9 @@ class Node(dict):
             if child.tag == 'tref':
                 url = parse_url(child.get(
                     '{http://www.w3.org/1999/xlink}href')).geturl()
-                child_tree = Tree(url=url, parent=self)
+                child_tree = Tree(url=url,
+                                  url_fetcher=self.get_url_fetcher_for(url),
+                                  parent=self)
                 child_tree.clear()
                 child_tree.update(self)
                 child_node = Node(
@@ -325,6 +343,7 @@ class Tree(Node):
         bytestring = kwargs.get('bytestring')
         file_obj = kwargs.get('file_obj')
         url = kwargs.get('url')
+        self.url_fetcher = kwargs.get('url_fetcher')
         unsafe = kwargs.get('unsafe')
         parent = kwargs.get('parent')
         parent_children = kwargs.get('parent_children')
@@ -354,7 +373,8 @@ class Tree(Node):
                 root_parent = root_parent.parent
             tree = root_parent.xml_tree
         else:
-            bytestring = bytestring or read_url(parse_url(self.url))
+            bytestring = bytestring or \
+                         self.fetch_url(parse_url(self.url), False)
             if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
                 bytestring = gzip.decompress(bytestring)
             parser = ElementTree.XMLParser(

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -60,7 +60,6 @@ class URLFetcher(object):
         """
         return self
 
-
     def __validate_url(self, url):
         """Validate ``url`` and raise Error if url is invalid.
 

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -42,12 +42,8 @@ class URLFetcher(object):
     """
 
     def fetch(self, url):
-        """Fetch the content of ``url``.
-
-        Validates the URL before fetching the content.
-        """
-        self.__validate_url(url)
-        return self.__read_url(url)
+        """Fetch the content of ``url``."""
+        return urlopen(Request(url, headers=HTTP_HEADERS)).read()
 
     def fetcher_for(self, url):
         """Answer URLFetcher to handle ``url``.
@@ -59,35 +55,6 @@ class URLFetcher(object):
         specifically.
         """
         return self
-
-    def __validate_url(self, url):
-        """Validate ``url`` and raise Error if url is invalid.
-
-        Default implementation: accept all URLs.
-
-        Override this method in a subclass for validating URLs.
-        """
-        return
-
-    def __open_url(self, url):
-        """Open ``url`` and answer instance which supports ``read()`` protocol.
-
-        Default implementation: open URL using urllib.request.urlopen.
-
-        Override this method in a subclass for opening URLs.
-        If ``__read_url()`` is also overridden, this method might not be used
-        anymore.
-        """
-        return urlopen(Request(url, headers=HTTP_HEADERS))
-
-    def __read_url(self, url):
-        """Read the content of ``url``.
-
-        Default implementation: read URL response from urllib.response.
-
-        Override this method in a subclass for reading the content of URLs.
-        """
-        return self.__open_url(url).read()
 
 
 def parse_url(url, base=None):

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -32,6 +32,65 @@ HTTP_HEADERS = {'User-Agent': 'CairoSVG {}'.format(__version__)}
 URL = re.compile(r'url\((.+)\)')
 
 
+class URLFetcher(object):
+    """Default implementation for URLFetcher.
+
+    It will retrieve many scheme's by default like ftp, http, file and data.
+    No specific restrictions (for size or location) will be applied.
+    Subclass this class to implement restrictions or implement custom schemes
+    (protocols).
+    """
+
+    def fetch(self, url):
+        """Fetch the content of ``url``.
+
+        Validates the URL before fetching the content.
+        """
+        self.__validate_url(url)
+        return self.__read_url(url)
+
+    def fetcher_for(self, url):
+        """Answer URLFetcher to handle ``url``.
+
+        Default implementation: answer self (ie all fetchers are same).
+
+        Override this method to handle specific resource types (like images or
+        CSSs) specifically. It may also be used to handle 'child' elements
+        specifically.
+        """
+        return self
+
+
+    def __validate_url(self, url):
+        """Validate ``url`` and raise Error if url is invalid.
+
+        Default implementation: accept all URLs.
+
+        Override this method in a subclass for validating URLs.
+        """
+        return
+
+    def __open_url(self, url):
+        """Open ``url`` and answer instance which supports ``read()`` protocol.
+
+        Default implementation: open URL using urllib.request.urlopen.
+
+        Override this method in a subclass for opening URLs.
+        If ``__read_url()`` is also overridden, this method might not be used
+        anymore.
+        """
+        return urlopen(Request(url, headers=HTTP_HEADERS))
+
+    def __read_url(self, url):
+        """Read the content of ``url``.
+
+        Default implementation: read URL response from urllib.response.
+
+        Override this method in a subclass for reading the content of URLs.
+        """
+        return self.__open_url(url).read()
+
+
 def parse_url(url, base=None):
     """Parse an URL.
 
@@ -74,10 +133,19 @@ def parse_url(url, base=None):
     return urlparse(url or '')
 
 
-def read_url(url):
-    """Get bytes in a parsed ``url``."""
+def read_url(url, url_fetcher):
+    """Get bytes in a parsed ``url`` using ``url_fetcher``.
+
+    If ``url_fetcher`` is None a default (no limitations) URLFetcher is used.
+    """
     if url.scheme:
         url = url.geturl()
     else:
         url = 'file://{}'.format(os.path.abspath(url.geturl()))
-    return urlopen(Request(url, headers=HTTP_HEADERS)).read()
+
+    if url_fetcher is None:
+        if not hasattr(read_url, 'default_url_fetcher'):
+            read_url.default_url_fetcher = URLFetcher()
+        url_fetcher = read_url.default_url_fetcher
+
+    return url_fetcher.fetch(url)


### PR DESCRIPTION
Added URLFetcher class to handle the retrieval of URLs (CSS, images, etc). The class is setup in such a way that it allows new child-fetchers to be created. This can be used for example to handle images in a special way. The class also allows restricting the URLs retrieved. This can be used to prevent URLs like "file:///dev/passwd" from being used. A feature useful if CairoSVG is part of a server application.

Currently there is only a default URLFetcher implementation which allows all URLs. This is similar to the current implementation.