### PR TITLE
Improve CSS performance by caching CSS resources

### DIFF
--- a/cairosvg/bounding_box.py
+++ b/cairosvg/bounding_box.py
@@ -358,7 +358,8 @@ def bounding_box_group(surface, node):
 def bounding_box_use(surface, node):
     """Get the bounding box of a ``use`` node."""
     href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
-    tree = Tree(url=href, url_fetcher=node.url_fetcher, parent=node)
+    tree = Tree(url=href, url_fetcher=node.url_fetcher, parent=node,
+                css_cache=surface.css_cache)
     if not match_features(tree.xml_tree):
         return None
     return calculate_bounding_box(surface, tree)

--- a/cairosvg/css.py
+++ b/cairosvg/css.py
@@ -41,7 +41,7 @@ def find_stylesheets(tree, url):
                 if stylesheet is None:
                     stylesheet = tinycss.make_parser().parse_stylesheet_bytes(
                         tree.fetch_url(href))
-                        # tree.fetch_url(href, 'css'))
+                    # tree.fetch_url(href, 'css'))
                     tree.css_cache[href_string] = stylesheet
                 yield stylesheet
         process = process.getprevious()
@@ -68,7 +68,7 @@ def find_stylesheets_rules(tree, stylesheet, url):
             if stylesheet is None:
                 stylesheet = tinycss.make_parser().parse_stylesheet(
                     tree.fetch_url(css_url).decode('utf-8'))
-                    # tree.fetch_url(css_url, 'css').decode('utf-8'))
+                # tree.fetch_url(css_url, 'css').decode('utf-8'))
                 tree.css_cache[css_url_string] = stylesheet
 
             # Find rules in stylesheet

--- a/cairosvg/css.py
+++ b/cairosvg/css.py
@@ -41,7 +41,7 @@ def find_stylesheets(tree, url):
                 if stylesheet is None:
                     stylesheet = tinycss.make_parser().parse_stylesheet_bytes(
                         tree.fetch_url(href))
-                        #tree.fetch_url(href, 'css'))
+                        # tree.fetch_url(href, 'css'))
                     tree.css_cache[href_string] = stylesheet
                 yield stylesheet
         process = process.getprevious()
@@ -68,7 +68,7 @@ def find_stylesheets_rules(tree, stylesheet, url):
             if stylesheet is None:
                 stylesheet = tinycss.make_parser().parse_stylesheet(
                     tree.fetch_url(css_url).decode('utf-8'))
-                    #tree.fetch_url(css_url, 'css').decode('utf-8'))
+                    # tree.fetch_url(css_url, 'css').decode('utf-8'))
                 tree.css_cache[css_url_string] = stylesheet
 
             # Find rules in stylesheet

--- a/cairosvg/css.py
+++ b/cairosvg/css.py
@@ -41,6 +41,7 @@ def find_stylesheets(tree, url):
                 if stylesheet is None:
                     stylesheet = tinycss.make_parser().parse_stylesheet_bytes(
                         tree.fetch_url(href))
+                        #tree.fetch_url(href, 'css'))
                     tree.css_cache[href_string] = stylesheet
                 yield stylesheet
         process = process.getprevious()
@@ -67,6 +68,7 @@ def find_stylesheets_rules(tree, stylesheet, url):
             if stylesheet is None:
                 stylesheet = tinycss.make_parser().parse_stylesheet(
                     tree.fetch_url(css_url).decode('utf-8'))
+                    #tree.fetch_url(css_url, 'css').decode('utf-8'))
                 tree.css_cache[css_url_string] = stylesheet
 
             # Find rules in stylesheet

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -57,7 +57,7 @@ def update_def_href(surface, def_name, def_dict):
         def_dict[def_name] = Tree(
             url='#{}'.format(def_name), url_fetcher=def_node.url_fetcher,
             parent=href_node, parent_children=(not def_node.children),
-            tree_cache=surface.tree_cache)
+            tree_cache=surface.tree_cache, css_cache=surface.css_cache)
         # Inherit attributes generally not inherited
         for key, value in href_node.items():
             if key not in def_dict[def_name]:
@@ -362,7 +362,7 @@ def use(surface, node):
     href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
     tree = Tree(
         url=href, url_fetcher=node.url_fetcher, parent=node,
-        tree_cache=surface.tree_cache)
+        tree_cache=surface.tree_cache, css_cache=surface.css_cache)
 
     if not match_features(tree.xml_tree):
         surface.context.restore()

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -55,7 +55,8 @@ def image(surface, node):
             del node['y']
         tree = Tree(
             url=url.geturl(), url_fetcher=node.url_fetcher,
-            bytestring=image_bytes, tree_cache=surface.tree_cache)
+            bytestring=image_bytes, tree_cache=surface.tree_cache,
+            css_cache=surface.css_cache)
         tree_width, tree_height, viewbox = node_format(
             surface, tree, reference=False)
         if not viewbox:

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -266,6 +266,11 @@ class Node(dict):
             if child.tag == 'tref':
                 url = parse_url(child.get(
                     '{http://www.w3.org/1999/xlink}href')).geturl()
+                # No reference to tree or surface here to retrieve css_cache.
+                # TODO: decide whether to leave it (ie no caching here) or try
+                # to obtain css_cache from one of the parent nodes. The tref
+                # tag is not supported in SVG 1.2 or beyond, so usage might be
+                # limited.
                 child_tree = Tree(
                     url=url, url_fetcher=self.url_fetcher, parent=self)
                 child_tree.clear()
@@ -344,6 +349,7 @@ class Tree(Node):
         element_id = None
 
         self.url_fetcher = kwargs.get('url_fetcher', fetch)
+        self.css_cache = kwargs.get('css_cache', {})
 
         if bytestring is not None:
             self.url = url

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -158,6 +158,8 @@ class Surface(object):
         self.cursor_d_position = [0, 0]
         self.text_path_width = 0
         self.tree_cache = {(tree.url, tree.get('id')): tree}
+        self.css_cache = tree.css_cache if parent_surface is None \
+            else parent_surface.css_cache
         if parent_surface:
             self.markers = parent_surface.markers
             self.gradients = parent_surface.gradients


### PR DESCRIPTION
Guillaume,

By using the new url_fetchers it became clear that in different situations CSS files will be read more than once. (Not the result of the url_fetchers, but doing some tests with them revealed this fact). I implemented a ``css_cache`` somewhat similar to ``tree_cache`` (but different ;-). There is one location where it is difficult to keep the cache. This is when ``tref`` tags are used. See the comment in the code.

Below is a SVG file which references an external CSS file. Because of the internal references ``ref_rect1`` and ``ref_rect2`` a new XML tree is created (from existing nodes) and the stylesheets are then applied to the tree. This results in loading CSS resources multiple times (if for example ``@import`` statements are present as in the example). The example below will read the CSS resource 'test.css' three times in the current implementation. This pull request caches the CSS file and loads it a single time.

(There is a small conflict with my earlier pull request #125 where the resource type is added to the fetcher. This one is still based on current master.)


    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="40">
        <style type="text/css"><![CDATA[
            @import url("test.css");]]>
        </style>
        <defs>
            <rect id="ref_rect1" x="10" y="10" width="50" height="10"/>
            <rect id="ref_rect2" x="10" y="10" width="50" height="10"/>
        </defs>
        <use xlink:href="#ref_rect1" style="fill:#0000ff"/>
        <g transform="translate(30,10)">
            <use xlink:href="#ref_rect1" style="fill:#00ff00"/>
        </g>
        <use xlink:href="#ref_rect2" style="fill:#0000ff"/>
    </svg>
