### PR TITLE
Moved the two variables x/y_align to the top of the function

### DIFF
--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -67,6 +67,10 @@ def point_following_path(path, width):
 
 def text(surface, node):
     """Draw a text ``node``."""
+    
+    x_align = 0
+    y_align = 0
+    
     font_family = (
         (node.get('font-family') or 'sans-serif').split(',')[0].strip('"\' '))
     font_style = getattr(


### PR DESCRIPTION
 There were code paths accessible resulting in a traceback triggered by Y_align being undefined. I didn't investigate further why this happened, the problem was triggered by SVG generated by fabric.js. Since having code paths with undefined variables in them is not only ugly but an error I suggest to correct the error in the way suggested by the pull request because this a coverage only change to the code.