### PR TITLE
Add output size parameters

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -39,38 +39,42 @@ SURFACES = {
 
 def svg2svg(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
-            write_to=None):
+            write_to=None, output_width=None, output_height=None):
     return surface.SVGSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
-        unsafe=unsafe, write_to=write_to)
+        unsafe=unsafe, write_to=write_to, output_width=output_width,
+        output_height=output_height)
 
 
 def svg2png(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
-            write_to=None):
+            write_to=None, output_width=None, output_height=None):
     return surface.PNGSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
-        unsafe=unsafe, write_to=write_to)
+        unsafe=unsafe, write_to=write_to, output_width=output_width,
+        output_height=output_height)
 
 
 def svg2pdf(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
-            write_to=None):
+            write_to=None, output_width=None, output_height=None):
     return surface.PDFSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
-        unsafe=unsafe, write_to=write_to)
+        unsafe=unsafe, write_to=write_to, output_width=output_width,
+        output_height=output_height)
 
 
 def svg2ps(bytestring=None, *, file_obj=None, url=None, dpi=96,
            parent_width=None, parent_height=None, scale=1, unsafe=False,
-           write_to=None):
+           write_to=None, output_width=None, output_height=None):
     return surface.PSSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
-        write_to=write_to)
+        write_to=write_to, output_width=output_width,
+        output_height=output_height)
 
 
 svg2svg.__doc__ = surface.Surface.convert.__doc__.replace(
@@ -108,12 +112,21 @@ def main():
         '-u', '--unsafe', action='store_true',
         help='resolve XML entities and allow very large files '
              '(WARNING: vulnerable to XXE attacks and various DoS)')
+    parser.add_argument(
+        '--output-width', default=None, type=float,
+        help='desired output width in pixels')
+    parser.add_argument(
+        '--output-height', default=None, type=float,
+        help='desired output height in pixels')
+
     parser.add_argument('-o', '--output', default='-', help='output filename')
 
     options = parser.parse_args()
     kwargs = {
         'parent_width': options.width, 'parent_height': options.height,
-        'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe}
+        'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe,
+        'output_width': options.output_width,
+        'output_height': options.output_height}
     kwargs['write_to'] = (
         sys.stdout.buffer if options.output == '-' else options.output)
     if options.input == '-':

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -110,7 +110,8 @@ class Surface(object):
     @classmethod
     def convert(cls, bytestring=None, *, file_obj=None, url=None, dpi=96,
                 parent_width=None, parent_height=None, scale=1, unsafe=False,
-                write_to=None, **kwargs):
+                write_to=None, output_width=None, output_height=None,
+                **kwargs):
         """Convert a SVG document to the format for this class.
 
         Specify the input by passing one of these:
@@ -142,13 +143,15 @@ class Surface(object):
             **kwargs)
         output = write_to or io.BytesIO()
         instance = cls(
-            tree, output, dpi, None, parent_width, parent_height, scale)
+            tree, output, dpi, None, parent_width, parent_height, scale,
+            output_width, output_height)
         instance.finish()
         if write_to is None:
             return output.getvalue()
 
     def __init__(self, tree, output, dpi, parent_surface=None,
-                 parent_width=None, parent_height=None, scale=1):
+                 parent_width=None, parent_height=None,
+                 scale=1, output_width=None, output_height=None):
         """Create the surface from a filename or a file-like object.
 
         The rendered content is written to ``output`` which can be a filename,
@@ -185,8 +188,19 @@ class Surface(object):
         self.font_size = size(self, '12pt')
         self.stroke_and_fill = True
         width, height, viewbox = node_format(self, tree)
-        width *= scale
-        height *= scale
+
+        # If one of output_width or output_height is set, compute the scale
+        if output_width:
+            scale = output_width / width
+        elif output_height:
+            scale = output_height / height
+
+        if output_width and output_height:
+            width, height = output_width, output_height
+        else:
+            width *= scale
+            height *= scale
+
         # Actual surface dimensions: may be rounded on raster surfaces types
         self.cairo, self.width, self.height = self._create_surface(
             width * self.device_units_per_user_units,
@@ -196,8 +210,12 @@ class Surface(object):
         self.context.scale(
             self.device_units_per_user_units, self.device_units_per_user_units)
         # Initial, non-rounded dimensions
-        self.set_context_size(
-            width, height, viewbox, scale, preserved_ratio(tree))
+        if output_width and output_height:
+            self.set_context_size(
+                width, height, viewbox, scale, tree)
+        else:
+            self.set_context_size(
+                width, height, viewbox, scale, preserved_ratio(tree))
         self.context.move_to(0, 0)
         self.draw(tree)
 


### PR DESCRIPTION
I added output_width and output_height parameters to the converter. This is helpful when you want to resize an svg without knowing the original size.
The scale is computed from one parameter if only one dimension is specified, otherwise the width and height fields of the surface are directly set to the desired output size.