### PR TITLE
Add support to multi pages PDF

### DIFF
--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -140,7 +140,8 @@ class Surface(object):
         """
         trees = []
         if (bytestring is not None):
-            bytestrings = bytestring if isinstance(bytestring, list) else [bytestring]
+            bytestrings = bytestring if isinstance(bytestring, list)\
+                                     else [bytestring]
             for item in bytestrings:
                 trees.append(Tree(bytestring=item, unsafe=unsafe,
                                   **kwargs))

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -158,6 +158,9 @@ class Surface(object):
         if (tree_obj is not None):
             tree_objs = tree_obj if isinstance(tree_obj, list) else [tree_obj]
             trees.extend(tree_objs)
+        
+        if(not trees)
+            raise TypeError
 
         output = write_to or io.BytesIO()
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -173,7 +173,8 @@ class Surface(object):
             else:
                 instance.addPage(tree, parent_width, parent_height, scale)
 
-        instance.finish()
+        if instance is not None:
+           instance.finish()
         if write_to is None:
             return output.getvalue()
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -140,9 +140,8 @@ class Surface(object):
         """
         trees = []
         if (bytestring is not None):
-            bytestrings = bytestring if isinstance(bytestring, list)\
-                                     else [bytestring]
-            for item in bytestrings:
+            bss = bytestring if isinstance(bytestring, list) else [bytestring]
+            for item in bss:
                 trees.append(Tree(bytestring=item, unsafe=unsafe,
                                   **kwargs))
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -158,7 +158,7 @@ class Surface(object):
         if (tree_obj is not None):
             tree_objs = tree_obj if isinstance(tree_obj, list) else [tree_obj]
             trees.extend(tree_objs)
-        
+
         if not trees:
             raise TypeError
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -159,7 +159,7 @@ class Surface(object):
             tree_objs = tree_obj if isinstance(tree_obj, list) else [tree_obj]
             trees.extend(tree_objs)
         
-        if(not trees)
+        if not trees:
             raise TypeError
 
         output = write_to or io.BytesIO()

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -140,37 +140,38 @@ class Surface(object):
         """
         trees = []
         if (bytestrings is not None):
-            if not isinstance(bytestrings, list): 
+            if not isinstance(bytestrings, list):
                 bytestrings = [bytestrings]
             for bytestring in bytestrings:
-                trees.append(Tree(bytestring=bytestring, unsafe=unsafe, 
+                trees.append(Tree(bytestring=bytestring, unsafe=unsafe,
                                   **kwargs))
 
         if(file_objs is not None):
-            if not isinstance(file_objs, list): 
+            if not isinstance(file_objs, list):
                 file_objs = [file_objs]
             for file in file_objs:
                 trees.append(Tree(file_obj=file, unsafe=unsafe, **kwargs))
 
         if (urls is not None):
-            if not isinstance(urls, list): 
+            if not isinstance(urls, list):
                 urls = [urls]
             for url in urls:
                 trees.append(Tree(url=url, unsafe=unsafe, **kwargs))
 
         if (tree_objs is not None):
-            if not isinstance(tree_objs, list): 
+            if not isinstance(tree_objs, list):
                 tree_objs = [tree_objs]
             trees.extend(tree_objs)
 
         output = write_to or io.BytesIO()
 
+        instance = None
         for tree in trees:
-            if 'instance' in locals():
-                instance.addPage(tree, parent_width, parent_height, scale)
-            else:
-                instance = cls(tree, output, dpi, None, parent_width, 
+            if instance is None:
+                instance = cls(tree, output, dpi, None, parent_width,
                                parent_height, scale)
+            else:
+                instance.addPage(tree, parent_width, parent_height, scale)
 
         instance.finish()
         if write_to is None:
@@ -498,7 +499,7 @@ class PDFSurface(Surface):
         width *= scale
         height *= scale
         self.cairo.show_page()
-        self.set_context_size(width, height, viewbox, scale, 
+        self.set_context_size(width, height, viewbox, scale,
                               preserved_ratio(tree))
         self.cairo.set_size(width * self.device_units_per_user_units,
                             height * self.device_units_per_user_units)

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -139,23 +139,23 @@ class Surface(object):
 
         """
         trees = []
-        if (bytestring is not None):
+        if bytestring is not None:
             bss = bytestring if isinstance(bytestring, list) else [bytestring]
             for item in bss:
                 trees.append(Tree(bytestring=item, unsafe=unsafe,
                                   **kwargs))
 
-        if(file_obj is not None):
+        if file_obj is not None:
             file_objs = file_obj if isinstance(file_obj, list) else [file_obj]
             for item in file_objs:
                 trees.append(Tree(file_obj=item, unsafe=unsafe, **kwargs))
 
-        if (url is not None):
+        if url is not None:
             urls = url if isinstance(url, list) else [url]
             for item in urls:
                 trees.append(Tree(url=item, unsafe=unsafe, **kwargs))
 
-        if (tree_obj is not None):
+        if tree_obj is not None:
             tree_objs = tree_obj if isinstance(tree_obj, list) else [tree_obj]
             trees.extend(tree_objs)
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -140,22 +140,27 @@ class Surface(object):
         """
         trees = []
         if (bytestrings is not None):
-            if not isinstance(bytestrings, list): bytestrings = [bytestrings]
+            if not isinstance(bytestrings, list): 
+                bytestrings = [bytestrings]
             for bytestring in bytestrings:
-                trees.append(Tree(bytestring=bytestring, unsafe=unsafe, **kwargs))
+                trees.append(Tree(bytestring=bytestring, unsafe=unsafe, 
+                                  **kwargs))
 
         if(file_objs is not None):
-            if not isinstance(file_objs, list): file_objs = [file_objs]
+            if not isinstance(file_objs, list): 
+                file_objs = [file_objs]
             for file in file_objs:
                 trees.append(Tree(file_obj=file, unsafe=unsafe, **kwargs))
 
         if (urls is not None):
-            if not isinstance(urls, list): urls = [urls]
+            if not isinstance(urls, list): 
+                urls = [urls]
             for url in urls:
                 trees.append(Tree(url=url, unsafe=unsafe, **kwargs))
 
         if (tree_objs is not None):
-            if not isinstance(tree_objs, list): tree_objs = [tree_objs]
+            if not isinstance(tree_objs, list): 
+                tree_objs = [tree_objs]
             trees.extend(tree_objs)
 
         output = write_to or io.BytesIO()
@@ -164,8 +169,8 @@ class Surface(object):
             if 'instance' in locals():
                 instance.addPage(tree, parent_width, parent_height, scale)
             else:
-                instance = cls(
-                    tree, output, dpi, None, parent_width, parent_height, scale)
+                instance = cls(tree, output, dpi, None, parent_width, 
+                               parent_height, scale)
 
         instance.finish()
         if write_to is None:
@@ -493,8 +498,10 @@ class PDFSurface(Surface):
         width *= scale
         height *= scale
         self.cairo.show_page()
-        self.set_context_size(width, height, viewbox, scale, preserved_ratio(tree))
-        self.cairo.set_size(width * self.device_units_per_user_units, height * self.device_units_per_user_units)
+        self.set_context_size(width, height, viewbox, scale, 
+                              preserved_ratio(tree))
+        self.cairo.set_size(width * self.device_units_per_user_units,
+                            height * self.device_units_per_user_units)
         self.draw(tree)
         self.context.restore()
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -174,7 +174,7 @@ class Surface(object):
                 instance.addPage(tree, parent_width, parent_height, scale)
 
         if instance is not None:
-           instance.finish()
+            instance.finish()
         if write_to is None:
             return output.getvalue()
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -115,10 +115,10 @@ class Surface(object):
 
         Specify the input by passing one of these:
 
-        :param bytestring: The SVG source as a byte-string or array.
-        :param file_objs: A file-like object or array.
-        :param url: A filename or array.
-        :tree_objs: A Tree object or array
+        :param bytestring: The SVG source as a byte-string or list.
+        :param file_objs: A file-like object or list.
+        :param url: A filename or list.
+        :tree_objs: A Tree object or list
 
         Give some options:
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -156,8 +156,7 @@ class Surface(object):
                 trees.append(Tree(url=item, unsafe=unsafe, **kwargs))
 
         if (tree_obj is not None):
-            if not isinstance(tree_obj, list):
-                tree_objs = [tree_obj]
+            tree_objs = tree_obj if isinstance(tree_obj, list) else [tree_obj]
             trees.extend(tree_objs)
 
         output = write_to or io.BytesIO()

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -108,17 +108,17 @@ class Surface(object):
     surface_class = None
 
     @classmethod
-    def convert(cls, bytestrings=None, *, file_objs=None, urls=None, dpi=96,
+    def convert(cls, bytestring=None, *, file_obj=None, url=None, dpi=96,
                 parent_width=None, parent_height=None, scale=1, unsafe=False,
-                write_to=None, tree_objs=None, **kwargs):
+                write_to=None, tree_obj=None, **kwargs):
         """Convert a SVG document to the format for this class.
 
         Specify the input by passing one of these:
 
         :param bytestring: The SVG source as a byte-string or list.
-        :param file_objs: A file-like object or list.
+        :param file_obj: A file-like object or list.
         :param url: A filename or list.
-        :tree_objs: A Tree object or list
+        :tree_obj: A Tree object or list
 
         Give some options:
 
@@ -139,28 +139,25 @@ class Surface(object):
 
         """
         trees = []
-        if (bytestrings is not None):
-            if not isinstance(bytestrings, list):
-                bytestrings = [bytestrings]
-            for bytestring in bytestrings:
-                trees.append(Tree(bytestring=bytestring, unsafe=unsafe,
+        if (bytestring is not None):
+            bytestrings = bytestring if isinstance(bytestring, list) else [bytestring]
+            for item in bytestrings:
+                trees.append(Tree(bytestring=item, unsafe=unsafe,
                                   **kwargs))
 
-        if(file_objs is not None):
-            if not isinstance(file_objs, list):
-                file_objs = [file_objs]
-            for file in file_objs:
-                trees.append(Tree(file_obj=file, unsafe=unsafe, **kwargs))
+        if(file_obj is not None):
+            file_objs = file_obj if isinstance(file_obj, list) else [file_obj]
+            for item in file_objs:
+                trees.append(Tree(file_obj=item, unsafe=unsafe, **kwargs))
 
-        if (urls is not None):
-            if not isinstance(urls, list):
-                urls = [urls]
-            for url in urls:
-                trees.append(Tree(url=url, unsafe=unsafe, **kwargs))
+        if (url is not None):
+            urls = url if isinstance(url, list) else [url]
+            for item in urls:
+                trees.append(Tree(url=item, unsafe=unsafe, **kwargs))
 
-        if (tree_objs is not None):
-            if not isinstance(tree_objs, list):
-                tree_objs = [tree_objs]
+        if (tree_obj is not None):
+            if not isinstance(tree_obj, list):
+                tree_objs = [tree_obj]
             trees.extend(tree_objs)
 
         output = write_to or io.BytesIO()


### PR DESCRIPTION
I kept the interface the same, for compatibility with existing code, but adding the option to pass a list of bytestring, file_obj, url, or tree objects (this last one as an optimization when converting the same svg to multiple formats), instead of a single object only. 
For PDFs it should call the method addPage for each new page, except the first one. For all other formats it should raise NotImplementedError for now.