### PR TITLE
dx and dy attributes should not inherit

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -53,6 +53,8 @@ NOT_INHERITED_ATTRIBUTES = frozenset((
     'width',
     'x',
     'y',
+    'dx',
+    'dy',
     '{http://www.w3.org/1999/xlink}href',
 ))
 

--- a/test_non_regression/svg/tspan-dx-dy.svg
+++ b/test_non_regression/svg/tspan-dx-dy.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100" height="80" viewBox="0 0 100 80"
+     xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <desc>Using tspan's dx and dy attributes
+        for incremental positioning adjustments, combined
+        with dx and dy on the text.</desc>
+
+  <g font-family="Liberation Sans" font-size="14">
+      <defs>
+          <marker id="triangle" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="4" markerHeight="4" orient="auto" fill="#808080" stroke="none">
+              <path d="M 0 0 L 10 5 L 0 10 z"/>
+          </marker>
+      </defs>
+      <g>
+          <path d="M50,40L50,65" stroke="#808080" style="marker-end:url(#triangle)"/>
+      </g>
+      <text x="50" dx="0" y="40" dy="-16">
+          <tspan x="50" dx="0" text-anchor="middle">Point Load 1</tspan><tspan x="50" dx="0" dy="14" text-anchor="middle">2.70 kN</tspan>
+      </text>
+      <g stroke="#2c98f0">
+          <line x1="50" x2="80" y1="24" y2="24" />
+          <line x1="50" x2="80" y1="38" y2="38" />
+      </g>
+  </g>
+</svg>
+


### PR DESCRIPTION
I discovered an issue with text positioning when using dx and dy. Take this example:
```xml
<text x="50" dx="0" y="40" dy="-16">
  <tspan x="50" dx="0" text-anchor="middle">Point Load 1</tspan><tspan x="50" dx="0" dy="14" text-anchor="middle">2.70 kN</tspan>
</text>
```
The first tspan doesn't specify a dy, which should mean it is positioned at the same y location as the parent text node (ie. y=24).

Currently, when the text node is handled, the cursor position is updated to take dy into account: https://github.com/Kozea/CairoSVG/blob/8cd36fe42d106c28570339d2099a5a2895deb193/cairosvg/text.py#L229
The tspan should be drawn relative to that position, but the inheritance rules in the parser mean that because dy is unset, it inherits the value -16, which is applied again and the text is drawn too high.

The horizontal lines in the example are at y=24 and y=38, which should be aligned with the baselines for the tspans.

Before:
![before](https://user-images.githubusercontent.com/1201065/46836623-e4e7d100-cd77-11e8-81b3-71796be8e23d.png)

After:
![after](https://user-images.githubusercontent.com/1201065/46836624-e4e7d100-cd77-11e8-9bb8-9a38dc272c6d.png)

Inkscape:
![inkscape](https://user-images.githubusercontent.com/1201065/46836625-e5806780-cd77-11e8-9310-f91603ffeb69.png)
