### PR TITLE
Fix for PDF texts not being selectable

### DIFF
--- a/cairosvg/__main__.py
+++ b/cairosvg/__main__.py
@@ -58,6 +58,9 @@ def main(argv=None, stdout=None, stdin=None):
     parser.add_argument(
         '--output-height', default=None, type=float,
         help='desired output height in pixels')
+    parser.add_argument(
+        '--text-as-text', action='store_true',
+        help='saves text in PDF as text instead of paths')
 
     parser.add_argument('-o', '--output', default='-', help='output filename')
 
@@ -66,7 +69,8 @@ def main(argv=None, stdout=None, stdin=None):
         'parent_width': options.width, 'parent_height': options.height,
         'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe,
         'output_width': options.output_width,
-        'output_height': options.output_height}
+        'output_height': options.output_height, 
+        'text-as-text':options.text_as_text}
     stdin = stdin or sys.stdin
     stdout = stdout or sys.stdout
     kwargs['write_to'] = (

--- a/cairosvg/__main__.py
+++ b/cairosvg/__main__.py
@@ -70,7 +70,7 @@ def main(argv=None, stdout=None, stdin=None):
         'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe,
         'output_width': options.output_width,
         'output_height': options.output_height, 
-        'text-as-text':options.text_as_text}
+        'draw_text_as_text':options.text_as_text}
     stdin = stdin or sys.stdin
     stdout = stdout or sys.stdout
     kwargs['write_to'] = (

--- a/cairosvg/__main__.py
+++ b/cairosvg/__main__.py
@@ -69,8 +69,8 @@ def main(argv=None, stdout=None, stdin=None):
         'parent_width': options.width, 'parent_height': options.height,
         'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe,
         'output_width': options.output_width,
-        'output_height': options.output_height, 
-        'draw_text_as_text':options.text_as_text}
+        'output_height': options.output_height,
+        'draw_text_as_text': options.text_as_text}
     stdin = stdin or sys.stdin
     stdout = stdout or sys.stdout
     kwargs['write_to'] = (

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -426,7 +426,7 @@ class Surface(object):
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
             if self.draw_text_as_text and TAGS[node.tag] == text:
                 self.cursor_position, self.cursor_d_position, \
-                self.text_path_width = save_cursor
+                    self.text_path_width = save_cursor
                 text(self, node, draw_as_text=True)
             else:
                 self.context.fill_preserve()

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -424,12 +424,12 @@ class Surface(object):
                 if node.get('fill-rule') == 'evenodd':
                     self.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
-                if self.draw_text_as_text and TAGS[node.tag] == text:
-                    self.cursor_position, self.cursor_d_position, \
-                    self.text_path_width = save_cursor
-                    text(self, node, draw_as_text=True)
-                else:
-                    self.context.fill_preserve()
+            if self.draw_text_as_text and TAGS[node.tag] == text:
+                self.cursor_position, self.cursor_d_position, \
+                self.text_path_width = save_cursor
+                text(self, node, draw_as_text=True)
+            else:
+                self.context.fill_preserve()
             self.context.restore()
 
             # Stroke

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -380,6 +380,9 @@ class Surface(object):
                 self.context.clip()
                 self.context.set_fill_rule(cairo.FILL_RULE_WINDING)
 
+        save_cursor = (self.cursor_position, self.cursor_d_position,
+                       self.text_path_width)
+
         # Only draw known tags
         if node.tag in TAGS and \
            not (self.draw_text_as_text and TAGS[node.tag] == text):
@@ -422,10 +425,12 @@ class Surface(object):
                 if node.get('fill-rule') == 'evenodd':
                     self.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
-            if self.draw_text_as_text and TAGS[node.tag] == text:
-                text(self, node, draw_as_text=True)
-            else:
-                self.context.fill_preserve()
+                if self.draw_text_as_text and TAGS[node.tag] == text:
+                    self.cursor_position, self.cursor_d_position, \
+                    self.text_path_width = save_cursor
+                    text(self, node, draw_as_text=True)
+                else:
+                    self.context.fill_preserve()
             self.context.restore()
 
             # Stroke

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -382,7 +382,7 @@ class Surface(object):
 
         # Only draw known tags
         if node.tag in TAGS and \
-           not (self.draw_text_as_text and TAGS[node.tag] != text):
+           not (self.draw_text_as_text and TAGS[node.tag] == text):
             try:
                 TAGS[node.tag](self, node)
             except PointError:

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -382,7 +382,7 @@ class Surface(object):
 
         # Only draw known tags
         if node.tag in TAGS and \
-            not (self.draw_text_as_text and TAGS[node.tag] != text):
+           not (self.draw_text_as_text and TAGS[node.tag] != text):
             try:
                 TAGS[node.tag](self, node)
             except PointError:

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -129,9 +129,9 @@ class Surface(object):
         :param unsafe: A boolean allowing XML entities and very large files
                        (WARNING: vulnerable to XXE attacks and various DoS).
         :param draw_text_as_text: Draw text as text, instead of paths, reducing
-                       the file size in PDFs and allowing text selection.May
+                       the file size in PDFs and allowing text selection. May
                        not support some path clipping operations.
-                       
+
         Specifiy the output with:
 
         :param write_to: The filename of file-like object where to write the
@@ -381,7 +381,8 @@ class Surface(object):
                 self.context.set_fill_rule(cairo.FILL_RULE_WINDING)
 
         # Only draw known tags
-        if node.tag in TAGS and not (self.draw_text_as_text and TAGS[node.tag] != text):
+        if node.tag in TAGS and 
+            not (self.draw_text_as_text and TAGS[node.tag] != text):
             try:
                 TAGS[node.tag](self, node)
             except PointError:
@@ -422,7 +423,7 @@ class Surface(object):
                     self.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
             if self.draw_text_as_text and TAGS[node.tag] == text:
-                text(self, node, draw_as_text = True)
+                text(self, node, draw_as_text=True)
             else:
                 self.context.fill_preserve()
             self.context.restore()

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -381,7 +381,7 @@ class Surface(object):
                 self.context.set_fill_rule(cairo.FILL_RULE_WINDING)
 
         # Only draw known tags
-        if node.tag in TAGS and 
+        if node.tag in TAGS and \
             not (self.draw_text_as_text and TAGS[node.tag] != text):
             try:
                 TAGS[node.tag](self, node)

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -111,7 +111,7 @@ class Surface(object):
     def convert(cls, bytestring=None, *, file_obj=None, url=None, dpi=96,
                 parent_width=None, parent_height=None, scale=1, unsafe=False,
                 write_to=None, output_width=None, output_height=None,
-                **kwargs):
+                draw_text_as_text=False, **kwargs):
         """Convert a SVG document to the format for this class.
 
         Specify the input by passing one of these:
@@ -128,7 +128,10 @@ class Surface(object):
         :param scale: The ouptut scaling factor.
         :param unsafe: A boolean allowing XML entities and very large files
                        (WARNING: vulnerable to XXE attacks and various DoS).
-
+        :param draw_text_as_text: Draw text as text, instead of paths, reducing
+                       the file size in PDFs and allowing text selection.May
+                       not support some path clipping operations.
+                       
         Specifiy the output with:
 
         :param write_to: The filename of file-like object where to write the
@@ -144,14 +147,15 @@ class Surface(object):
         output = write_to or io.BytesIO()
         instance = cls(
             tree, output, dpi, None, parent_width, parent_height, scale,
-            output_width, output_height)
+            output_width, output_height, draw_text_as_text)
         instance.finish()
         if write_to is None:
             return output.getvalue()
 
     def __init__(self, tree, output, dpi, parent_surface=None,
                  parent_width=None, parent_height=None,
-                 scale=1, output_width=None, output_height=None):
+                 scale=1, output_width=None, output_height=None,
+                 draw_text_as_text=False):
         """Create the surface from a filename or a file-like object.
 
         The rendered content is written to ``output`` which can be a filename,
@@ -185,6 +189,7 @@ class Surface(object):
         self._old_parent_node = self.parent_node = None
         self.output = output
         self.dpi = dpi
+        self.draw_text_as_text = draw_text_as_text
         self.font_size = size(self, '12pt')
         self.stroke_and_fill = True
         width, height, viewbox = node_format(self, tree)
@@ -376,7 +381,7 @@ class Surface(object):
                 self.context.set_fill_rule(cairo.FILL_RULE_WINDING)
 
         # Only draw known tags
-        if node.tag in TAGS:
+        if node.tag in TAGS and not (self.draw_text_as_text and TAGS[node.tag] != text):
             try:
                 TAGS[node.tag](self, node)
             except PointError:
@@ -416,7 +421,10 @@ class Surface(object):
                 if node.get('fill-rule') == 'evenodd':
                     self.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
                 self.context.set_source_rgba(*color(paint_color, fill_opacity))
-            self.context.fill_preserve()
+            if self.draw_text_as_text and TAGS[node.tag] == text:
+                text(self, node, draw_as_text = True)
+            else:
+                self.context.fill_preserve()
             self.context.restore()
 
             # Stroke

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -384,8 +384,7 @@ class Surface(object):
                        self.text_path_width)
 
         # Only draw known tags
-        if node.tag in TAGS and \
-           not (self.draw_text_as_text and TAGS[node.tag] == text):
+        if node.tag in TAGS:
             try:
                 TAGS[node.tag](self, node)
             except PointError:

--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -1,5 +1,5 @@
 # This file is part of CairoSVG
-# Copyright © 2010-2018 Kozea
+# Copyright © 2010-2015 Kozea
 #
 # This library is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -65,7 +65,7 @@ def point_following_path(path, width):
                 return x, y
 
 
-def text(surface, node):
+def text(surface, node, draw_as_text=False):
     """Draw a text ``node``."""
     font_family = (
         (node.get('font-family') or 'sans-serif').split(',')[0].strip('"\' '))
@@ -143,7 +143,6 @@ def text(surface, node):
         elif (alignment_baseline == 'text-before-edge' or
               alignment_baseline == 'before_edge' or
               alignment_baseline == 'top' or
-              alignment_baseline == 'hanging' or
               alignment_baseline == 'text-top'):
             y_align = ascent
         elif (alignment_baseline == 'text-after-edge' or
@@ -161,9 +160,7 @@ def text(surface, node):
         surface.context.new_path()
         length = path_length(cairo_path) + x_bearing
         start_offset = size(surface, node.get('startOffset', 0), length)
-        if node.tag == 'textPath':
-            surface.text_path_width += start_offset
-        surface.text_path_width -= x_align
+        surface.text_path_width += start_offset - x_align
         bounding_box = extend_bounding_box(bounding_box, ((start_offset, 0),))
 
     if node.text:
@@ -217,7 +214,11 @@ def text(surface, node):
 
             # Only draw characters with 'content' (workaround for bug in cairo)
             if not letter.isspace():
-                surface.context.show_text(letter)
+                if draw_as_text:
+                    point = surface.context.get_current_point()
+                    surface.context.show_text(letter)
+                    surface.context.move_to(*point)
+                surface.context.text_path(letter)
             surface.context.restore()
             if not text_path:
                 surface.cursor_position = cursor_position

--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -217,10 +217,9 @@ def text(surface, node, draw_as_text=False):
             # Only draw characters with 'content' (workaround for bug in cairo)
             if not letter.isspace():
                 if draw_as_text:
-                    point = surface.context.get_current_point()
                     surface.context.show_text(letter)
-                    surface.context.move_to(*point)
-                surface.context.text_path(letter)
+                else:
+                    surface.context.text_path(letter)
             surface.context.restore()
             if not text_path:
                 surface.cursor_position = cursor_position

--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -217,7 +217,7 @@ def text(surface, node):
 
             # Only draw characters with 'content' (workaround for bug in cairo)
             if not letter.isspace():
-                surface.context.text_path(letter)
+                surface.context.show_text(letter)
             surface.context.restore()
             if not text_path:
                 surface.cursor_position = cursor_position

--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -1,5 +1,5 @@
 # This file is part of CairoSVG
-# Copyright © 2010-2015 Kozea
+# Copyright © 2010-2018 Kozea
 #
 # This library is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -160,7 +160,9 @@ def text(surface, node, draw_as_text=False):
         surface.context.new_path()
         length = path_length(cairo_path) + x_bearing
         start_offset = size(surface, node.get('startOffset', 0), length)
-        surface.text_path_width += start_offset - x_align
+        if node.tag == 'textPath':
+            surface.text_path_width += start_offset		
+        surface.text_path_width -= x_align
         bounding_box = extend_bounding_box(bounding_box, ((start_offset, 0),))
 
     if node.text:

--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -161,7 +161,7 @@ def text(surface, node, draw_as_text=False):
         length = path_length(cairo_path) + x_bearing
         start_offset = size(surface, node.get('startOffset', 0), length)
         if node.tag == 'textPath':
-            surface.text_path_width += start_offset		
+            surface.text_path_width += start_offset
         surface.text_path_width -= x_align
         bounding_box = extend_bounding_box(bounding_box, ((start_offset, 0),))
 


### PR DESCRIPTION
Decreases PDF file size and allows text selection/copy by rendering the texts as text, instead of paths.

Fixes issue #212.