### PR TITLE
cache XML trees for SVG use tags to accelerate chart rendering

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -27,6 +27,12 @@ from xml.etree.ElementTree import Element
 import cssselect2
 from defusedxml import ElementTree
 
+from cachetools import cached
+
+@cached(cache={})
+def _fromstring(*args, **kwargs):
+    return ElementTree.fromstring(*args, **kwargs)
+
 from . import css
 from .features import match_features
 from .helpers import flatten, pop_rotation, rotations
@@ -394,7 +400,7 @@ class Tree(Node):
                     parse_url(self.url), 'image/svg+xml')
             if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
                 bytestring = gzip.decompress(bytestring)
-            tree = ElementTree.fromstring(
+            tree = _fromstring(
                 bytestring, forbid_entities=not unsafe,
                 forbid_external=not unsafe)
         self.xml_tree = tree

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
   defusedxml
   pillow
   tinycss2
+  cachetools
 tests_require =
   pytest-cov
   pytest-flake8


### PR DESCRIPTION
I was rendering a document with weasyprint with a complex SVG scatter chart with ~500 points which are all symbolized by SVG use tags which reference a g in the defs section by xlink.

I profiled with cProfile and I found that it was parsing the symbol XML for every single point on the chart. This was consuming 40-50% of the overall program execution time.

So I used cachetools to cache use tag trees from the raw XML. This cut the time to render the document almost in half. Re-profiling revealed no further XML parsing bottlenecks.

I noticed there is already a tree caching mechanism in place here, but clearly it's not being very efficient or aggressive in it's caching, since it's missing on the use tags' xlink-ed tree. So rather than merge this and add the dependency you or somebody might want to try tuning that existing cache.

this increases memory usage by the size of the unique children of all the defs sections in all the charts in the doc + their parsed trees. this should generally be a non-issue since defs is typically used for chart symbology and so are likely to be small and identical across charts. Even if there were large complex graphics in the defs it would probably still be worth the gain in CPU time since putting something in defs usually implies you'll be referencing it with use multiple times.

before/after profiles attached

[cprofileoutput.zip](https://github.com/Kozea/CairoSVG/files/2687009/cprofileoutput.zip)

