### PR TITLE
If the referenced url starts with '#' and no URL is given, use root parent's tree

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -383,7 +383,9 @@ class Tree(Node):
         else:
             raise TypeError(
                 'No input. Use one of bytestring, file_obj or url.')
-        if parent and self.url == parent.url:
+        if parent and (
+            self.url == parent.url or
+                (url.startswith('#') and not self.url)):
             root_parent = parent
             while root_parent.parent:
                 root_parent = root_parent.parent


### PR DESCRIPTION
This solves an issue that might happen when a resource doesn't have a physical location but is loaded from memory and includes reference to itself via the `use` element:
```xml
<use xlink:href="#reference"/>
```
If the SVG is loaded from a physical location then there is no problem except the resource will be loaded and processed again.