### PR TITLE
Fix recursion error on malformed use tags

### DIFF
--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -359,7 +359,12 @@ def use(surface, node):
         del node['viewBox']
     if 'mask' in node:
         del node['mask']
-    href = parse_url(node.get('{http://www.w3.org/1999/xlink}href')).geturl()
+
+    # the href attr should be in the xlink namespace,
+    # but some libs do not respect this
+    href = node.get('{http://www.w3.org/1999/xlink}href') or node.get('href')
+    href = parse_url(href).geturl()
+
     tree = Tree(
         url=href, url_fetcher=node.url_fetcher, parent=node,
         tree_cache=surface.tree_cache, unsafe=node.unsafe)

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -365,6 +365,9 @@ def use(surface, node):
     href = node.get('{http://www.w3.org/1999/xlink}href') or node.get('href')
     href = parse_url(href).geturl()
 
+    if not href:
+        raise ValueError('Invalid <use> tag: {!r}'.format(node))
+
     tree = Tree(
         url=href, url_fetcher=node.url_fetcher, parent=node,
         tree_cache=surface.tree_cache, unsafe=node.unsafe)


### PR DESCRIPTION
`<use>` tags with an href attribute that isn't in the right namespace (xlink), trigger an infinite recursion error.

This PR introduce a ValueError for malfformed use tags, and lookup href attrs more leniently to support svg generated by some tools (chrome also support those mis-namespaced attributes, and the "lottie-web" framework generate svg files like this)

this fixes #187 