### PR TITLE
Adding test case for an issue with <image> inside <pattern>

### DIFF
--- a/test_non_regression/svg/pattern02.svg
+++ b/test_non_regression/svg/pattern02.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" 
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="8cm" height="4cm" viewBox="0 0 800 400" version="1.1"
+     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <pattern id="ImagePattern" patternUnits="userSpaceOnUse"
+             x="0" y="0" width="100" height="100"
+             viewBox="0 0 10 10" >
+      <image x="240" y="0" width="240" height="150" xlink:href="../images/struct-image-01.jpg"/>
+    </pattern> 
+  </defs>
+
+  <!-- Outline the drawing area in blue -->
+  <rect fill="none" stroke="blue" 
+        x="1" y="1" width="798" height="398"/>
+
+  <!-- The ellipse is filled using a triangle pattern paint server
+       and stroked with black -->
+  <ellipse fill="url(#ImagePattern)" stroke="black" stroke-width="5"  
+           cx="400" cy="200" rx="350" ry="150" />
+</svg>
+
+


### PR DESCRIPTION
Hi

I couldn't find where to open an issue.

This is an example of a currently failing scenario:
after running `cairosvg -o pattern02.pdf ./pattern02.svg`
the resulting PDF contains no visible image,
whereas a web browser would display the image for the same SVG code.

This new test failed is closely based on https://github.com/Kozea/CairoSVG/blob/master/test_non_regression/svg/pattern01.svg

I'd be happy to implement a fix if someone can point me to a starting point to solve this bug.