### PR TITLE
Fix usage with a relative input SVG file path

### DIFF
--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -21,13 +21,14 @@ Images manager.
 
 import os.path
 from io import BytesIO
+from urllib.parse import urlparse
 
 from PIL import Image
 
 from .helpers import node_format, preserve_ratio, size
 from .parser import Tree
 from .surface import cairo
-from .url import parse_url
+from .url import _parse_url
 
 IMAGE_RENDERING = {
     'optimizeQuality': cairo.FILTER_BEST,
@@ -40,7 +41,7 @@ def image(surface, node):
     base_url = node.get('{http://www.w3.org/XML/1998/namespace}base')
     if not base_url and node.url:
         base_url = os.path.dirname(node.url) + '/'
-    url = parse_url(node.get_href(), base_url)
+    url = _parse_url(node.get('{http://www.w3.org/1999/xlink}href'), base_url)
     image_bytes = node.fetch_url(url, 'image/*')
 
     if len(image_bytes) < 5:
@@ -59,7 +60,7 @@ def image(surface, node):
         if 'y' in node:
             del node['y']
         tree = Tree(
-            url=url.geturl(), url_fetcher=node.url_fetcher,
+            url=urlparse(url).geturl(), url_fetcher=node.url_fetcher,
             bytestring=image_bytes, tree_cache=surface.tree_cache,
             unsafe=node.unsafe)
         tree_width, tree_height, viewbox = node_format(

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -107,6 +107,10 @@ def parse_url(url, base=None):
     the "folder" part of it is prepended to the URL.
 
     """
+    return urlparse(_parse_url(url, base) or '')
+
+
+def _parse_url(url, base):
     if url:
         match = URL.search(url)
         if match:
@@ -142,7 +146,7 @@ def parse_url(url, base=None):
                 # `urljoin` automatically uses the "folder" part of `base`
                 url = urljoin(base, url)
         url = normalize_url(url.strip('\'"'))
-    return urlparse(url or '')
+    return url
 
 
 def read_url(url, url_fetcher, resource_type):
@@ -150,10 +154,12 @@ def read_url(url, url_fetcher, resource_type):
 
     If ``url_fetcher`` is None a default (no limitations) URLFetcher is used.
     """
-    if url.scheme:
-        url = url.geturl()
+    parsed_url = urlparse(url) if isinstance(url, str) else url
+    str_url = url if isinstance(url, str) else url.geturl()
+    if parsed_url.scheme:
+        url = parsed_url.geturl()
     else:
-        url = 'file://{}'.format(os.path.abspath(url.geturl()))
+        url = 'file://{}'.format(os.path.abspath(str_url))
         url = normalize_url(url)
 
     return url_fetcher(url, resource_type)

--- a/test_non_regression/test_non_regression.py
+++ b/test_non_regression/test_non_regression.py
@@ -58,3 +58,7 @@ def test_image(svg_filename):
         raise AssertionError(
             'Images are different: {} {}'.format(
                 ref_png.name, test_png.name))
+
+
+def test_image_with_relative_path():
+    test_image('./struct-image-01-t.svg')


### PR DESCRIPTION
Without this fix, one needs to always pass absolute path to the `cairosvg` command.

There are probably other ways to fix this, maybe by calling `os.path.abspath` in `cairosvg.parser.Tree.__init__`

Quick test:

    CAIROSVG_TEST_FILES=struct-image-01-t.svg pytest test_non_regression/test_non_regression.py