### PR TITLE
Add background_color, negate_colors, and invert_images options

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -52,40 +52,52 @@ SURFACES = {
 
 def svg2svg(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
+            background_color=None, negate_colors=False, invert_images=False,
             write_to=None, output_width=None, output_height=None):
     return surface.SVGSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
+        background_color=background_color,
+        negate_colors=negate_colors, invert_images=invert_images,
         unsafe=unsafe, write_to=write_to, output_width=output_width,
         output_height=output_height)
 
 
 def svg2png(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
+            background_color=None, negate_colors=False, invert_images=False,
             write_to=None, output_width=None, output_height=None):
     return surface.PNGSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
+        background_color=background_color,
+        negate_colors=negate_colors, invert_images=invert_images,
         unsafe=unsafe, write_to=write_to, output_width=output_width,
         output_height=output_height)
 
 
 def svg2pdf(bytestring=None, *, file_obj=None, url=None, dpi=96,
             parent_width=None, parent_height=None, scale=1, unsafe=False,
+            background_color=None, negate_colors=False, invert_images=False,
             write_to=None, output_width=None, output_height=None):
     return surface.PDFSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
+        background_color=background_color,
+        negate_colors=negate_colors, invert_images=invert_images,
         unsafe=unsafe, write_to=write_to, output_width=output_width,
         output_height=output_height)
 
 
 def svg2ps(bytestring=None, *, file_obj=None, url=None, dpi=96,
            parent_width=None, parent_height=None, scale=1, unsafe=False,
+           background_color=None, negate_colors=False, invert_images=False,
            write_to=None, output_width=None, output_height=None):
     return surface.PSSurface.convert(
         bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
         parent_width=parent_width, parent_height=parent_height, scale=scale,
+        background_color=background_color,
+        negate_colors=negate_colors, invert_images=invert_images,
         unsafe=unsafe, write_to=write_to, output_width=output_width,
         output_height=output_height)
 

--- a/cairosvg/__main__.py
+++ b/cairosvg/__main__.py
@@ -49,6 +49,14 @@ def main(argv=None, stdout=None, stdin=None):
     parser.add_argument(
         '-s', '--scale', default=1, type=float, help='output scaling factor')
     parser.add_argument(
+        '-bg', '--background', metavar='COLOR', help='output background color')
+    parser.add_argument(
+        '-n', '--negate-colors', action='store_true',
+        help='replace every vector color with its complement')
+    parser.add_argument(
+        '-i', '--invert-images', action='store_true',
+        help='replace every raster pixel with its complementary color')
+    parser.add_argument(
         '-u', '--unsafe', action='store_true',
         help='resolve XML entities and allow very large files '
              '(WARNING: vulnerable to XXE attacks and various DoS)')
@@ -65,6 +73,9 @@ def main(argv=None, stdout=None, stdin=None):
     kwargs = {
         'parent_width': options.width, 'parent_height': options.height,
         'dpi': options.dpi, 'scale': options.scale, 'unsafe': options.unsafe,
+        'background_color': options.background,
+        'negate_colors': options.negate_colors,
+        'invert_images': options.invert_images,
         'output_width': options.output_width,
         'output_height': options.output_height}
     stdin = stdin or sys.stdin

--- a/cairosvg/colors.py
+++ b/cairosvg/colors.py
@@ -253,3 +253,9 @@ def color(string, opacity=1):
         return plain_color + (opacity,)
 
     return (0, 0, 0, 1)
+
+
+def negate_color(rgba_tuple):
+    """Replace ``rgba_tuple`` with its complementary color."""
+    r, g, b, a = rgba_tuple
+    return (1 - r, 1 - g, 1 - b, a)

--- a/cairosvg/defs.py
+++ b/cairosvg/defs.py
@@ -22,7 +22,6 @@ This module handles clips, gradients, masks, patterns and external nodes.
 """
 
 from .bounding_box import calculate_bounding_box, is_non_empty_bounding_box
-from .colors import color
 from .features import match_features
 from .helpers import paint, size, transform
 from .parser import Tree
@@ -215,7 +214,7 @@ def draw_gradient(surface, node, name):
     offset = 0
     for child in gradient_node.children:
         offset = max(offset, size(surface, child.get('offset'), 1))
-        stop_color = color(
+        stop_color = surface.map_color(
             child.get('stop-color', 'black'),
             float(child.get('stop-opacity', 1)))
         gradient_pattern.add_color_stop_rgba(offset, *stop_color)
@@ -338,7 +337,7 @@ def apply_filter_after_painting(surface, node, name):
                 width *= size(surface, child.get('width', 0), 1)
                 height *= size(surface, child.get('height', 0), 1)
                 rect(surface, dict(x=x, y=y, width=width, height=height))
-                surface.context.set_source_rgba(*color(
+                surface.context.set_source_rgba(*surface.map_color(
                     paint(child.get('flood-color'))[1],
                     float(child.get('flood-opacity', 1))))
                 surface.context.fill()

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -111,7 +111,8 @@ class Surface(object):
     @classmethod
     def convert(cls, bytestring=None, *, file_obj=None, url=None, dpi=96,
                 parent_width=None, parent_height=None, scale=1, unsafe=False,
-                background_color=None, negate_colors=False, invert_images=False,
+                background_color=None,
+                negate_colors=False, invert_images=False,
                 write_to=None, output_width=None, output_height=None,
                 **kwargs):
         """Convert a SVG document to the format for this class.


### PR DESCRIPTION
This PR adds `--background_color` (`-bg`), `--negate_colors` (`-n`), and `--invert-images` (`-i`) options to CairoSVG.

**Sample output** (not included in this PR):  
https://github.com/mingaldrichgan/CairoSVG/tree/negate-out/test_non_regression/out