### PR TITLE
use "dominant-baseline" in addition to "alignment-baseline"

### DIFF
--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -126,7 +126,8 @@ def text(surface, node, draw_as_text=False):
     # this will at least make that possible.
     if max_x_advance > 0 and max_y_advance == 0:
         display_anchor = node.get('display-anchor')
-        alignment_baseline = node.get('alignment-baseline')
+        alignment_baseline = (node.get('dominant-baseline') or
+                              node.get('alignment-baseline'))
         if display_anchor == 'middle':
             y_align = -height / 2.0 - y_bearing
         elif display_anchor == 'top':

--- a/test_non_regression/svg/dominant_alignment_baseline.svg
+++ b/test_non_regression/svg/dominant_alignment_baseline.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 200 360" xmlns="http://www.w3.org/2000/svg">
+  <path d="M60,0 L60,360" stroke="grey" />
+  <g>
+    <path d="M20,20 L180,20" stroke="grey" />
+    <text text-anchor="start" x="60" y="20">start</text>
+    <path d="M20,50 L180,50" stroke="grey" />
+    <text text-anchor="middle" x="60" y="50">middle</text>
+    <path d="M20,80 L180,80" stroke="grey" />
+    <text text-anchor="end" x="60" y="80">end</text>
+  </g>
+
+  <g transform="translate(0,120)">
+    <path d="M20,20 L180,20" stroke="grey" />
+    <text dominant-baseline="baseline" x="60" y="20">baseline</text>
+    <path d="M20,50 L180,50" stroke="grey" />
+    <text dominant-baseline="middle" x="60" y="50">middle</text>
+    <path d="M20,80 L180,80" stroke="grey" />
+    <text dominant-baseline="hanging" x="60" y="80">hanging</text>
+  </g>
+
+  <g transform="translate(0,240)">
+    <path d="M20,20 L180,20" stroke="grey" />
+    <text dominant-baseline="baseline" alignment-baseline="top" x="60" y="20">baseline-top</text>
+    <path d="M20,50 L180,50" stroke="grey" />
+    <text dominant-baseline="baseline" alignment-baseline="hanging" x="60" y="50">baseline-hanging</text>
+    <path d="M20,80 L180,80" stroke="grey" />
+    <text dominant-baseline="hanging" alignment-baseline="baseline" x="60" y="80">hanging-baseline</text>
+  </g>
+</svg>


### PR DESCRIPTION
"alignment-baseline" works as "dominant-baseline" but is only valid on
text elements: `<tspan>`, `<tref>`, `<altGlyph>`, and `<textPath>`.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline

I also added a sample SVG file for  regression testing.
File generated by Cairo
![dominant_alignment_baseline](https://user-images.githubusercontent.com/5920036/65754354-28feed80-e111-11e9-85d2-7361d9efc151.png)

Svg rendered in browser:
![svg rendered in browser](https://raw.githubusercontent.com/Kozea/CairoSVG/b32e7820c619a6faa7b2847ae278e485ee00499b/test_non_regression/svg/dominant_alignment_baseline.svg?sanitize=true)