### PR TITLE
Fixed incorrect link to Pillow package website

### DIFF
--- a/pages/svg_support.rst
+++ b/pages/svg_support.rst
@@ -160,7 +160,7 @@ Painting raster images
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Included raster images are supported by the `Pillow
-<http://python-pillow.github.io/>`_ package.
+<https://python-pillow.org/>`_ package.
 
 
 Filtering painted regions

--- a/pages/user_documentation.rst
+++ b/pages/user_documentation.rst
@@ -35,7 +35,7 @@ CairoSVG can use `lxml <http://lxml.de/>`_ to parse the SVG file, and `tinycss
 only be supported in the ``style`` attributes.
 
 Embedded raster images other than PNG are handled by `Pillow
-<http://python-imaging.github.io/>`_.
+<https://python-pillow.org/>`_.
 
 
 CairoSVG


### PR DESCRIPTION
Your link for the "Pillow" package is incorrect. It should be [https://python-pillow.org/](https://python-pillow.org/).

I posted issue #256.