### PR TITLE
Improve support for font weights.

### DIFF
--- a/cairosvg/text.py
+++ b/cairosvg/text.py
@@ -72,8 +72,12 @@ def text(surface, node, draw_as_text=False):
     font_style = getattr(
         cairo, ('font_slant_{}'.format(node.get('font-style')).upper()),
         cairo.FONT_SLANT_NORMAL)
+    node_font_weight = node.get('font-weight')
+    if (node_font_weight and node_font_weight.isdigit()
+            and int(node_font_weight) >= 550):
+        node_font_weight = 'bold'
     font_weight = getattr(
-        cairo, ('font_weight_{}'.format(node.get('font-weight')).upper()),
+        cairo, ('font_weight_{}'.format(node_font_weight).upper()),
         cairo.FONT_WEIGHT_NORMAL)
     surface.context.select_font_face(font_family, font_style, font_weight)
     surface.context.set_font_size(surface.font_size)


### PR DESCRIPTION
Cairo only exposes "NORMAL" and "BOLD" weights; this patch interprets
numeric weights >= 550 as bold (previously any numeric weight was
interpreted as NORMAL).

The CSS standard says
- 400 = Normal, 500 = Medium, 600 = Semi Bold, 700 = Bold
and also says that applying "bolder" (resp. "lighter") to fonts with
- 350 <= w < 550 -> gives 700 (resp. 100)
- 550 <= w < 750 -> gives 900 (resp. 400)

hence the choice of a cutoff at 550.

I would need some help as to how to add a test, if required (but I tested the patch locally).