### PR TITLE
Try fixing a bug encountered when using cairosvg in Pyinstaller context

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -27,7 +27,7 @@ if hasattr(sys, 'frozen'):
     if hasattr(sys, '_MEIPASS'):
         # Frozen with PyInstaller
         # See https://github.com/Kozea/WeasyPrint/pull/540
-        ROOT = Path(sys._MEIPASS)
+        ROOT = Path(sys._MEIPASS) / 'cairosvg'
     else:
         # Frozen with something else (py2exe, etc.)
         # See https://github.com/Kozea/WeasyPrint/pull/269


### PR DESCRIPTION
Solves the same issue as documented in my other pull request. See that page for more details: https://github.com/Kozea/WeasyPrint/pull/1089