### PR TITLE
Adds Exif Transposition Support

### DIFF
--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -23,6 +23,7 @@ import os.path
 from io import BytesIO
 
 from PIL import Image, ImageOps
+from PIL.ImageOps import exif_transpose
 
 from .helpers import node_format, preserve_ratio, size
 from .parser import Tree
@@ -92,6 +93,7 @@ def image(surface, node):
     else:
         png_file = BytesIO()
         image = Image.open(BytesIO(image_bytes))
+        image = exif_transpose(image)
 
         if surface.map_image:
             image = surface.map_image(image)

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -23,7 +23,6 @@ import os.path
 from io import BytesIO
 
 from PIL import Image, ImageOps
-from PIL.ImageOps import exif_transpose
 
 from .helpers import node_format, preserve_ratio, size
 from .parser import Tree
@@ -92,8 +91,7 @@ def image(surface, node):
         return
     else:
         png_file = BytesIO()
-        image = Image.open(BytesIO(image_bytes))
-        image = exif_transpose(image)
+        image = ImageOps.exif_transpose(Image.open(BytesIO(image_bytes)))
 
         if surface.map_image:
             image = surface.map_image(image)


### PR DESCRIPTION
This should fix #278 Pillow had a [method](https://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.exif_transpose) to make the transformations according to EXIF orientations already, I just imported and applied in place.

I am not sure if I should have run any kind of tests, please let me know if I need to update and/or provide tests and documentation based on this fix