### PR TITLE
Added option to convert to EPS (encapsulated postscript)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 ==========
 
 CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF,
-PostScript and PNG files.
+EPS, PS, and PNG files.
 
 For further information, please visit the `CairoSVG Website
 <http://www.cairosvg.org/>`_.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
  CairoSVG
 ==========
 
-CairoSVG is a SVG converter based on Cairo. It can export SVG files to PDF,
+CairoSVG is an SVG converter based on Cairo. It can export SVG files to PDF,
 PostScript and PNG files.
 
 For further information, please visit the `CairoSVG Website

--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -46,6 +46,7 @@ SURFACES = {
     'PDF': surface.PDFSurface,
     'PNG': surface.PNGSurface,
     'PS': surface.PSSurface,
+    'EPS': surface.EPSSurface,
     'SVG': surface.SVGSurface,
 }
 
@@ -99,6 +100,18 @@ def svg2ps(bytestring=None, *, file_obj=None, url=None, dpi=96,
         output_width=output_width, output_height=output_height)
 
 
+def svg2eps(bytestring=None, *, file_obj=None, url=None, dpi=96,
+            parent_width=None, parent_height=None, scale=1, unsafe=False,
+            background_color=None, negate_colors=False, invert_images=False,
+            write_to=None, output_width=None, output_height=None):
+    return surface.EPSSurface.convert(
+        bytestring=bytestring, file_obj=file_obj, url=url, dpi=dpi,
+        parent_width=parent_width, parent_height=parent_height, scale=scale,
+        background_color=background_color, negate_colors=negate_colors,
+        invert_images=invert_images, unsafe=unsafe, write_to=write_to,
+        output_width=output_width, output_height=output_height)
+
+
 svg2svg.__doc__ = surface.Surface.convert.__doc__.replace(
     'the format for this class', 'SVG')
 svg2png.__doc__ = surface.Surface.convert.__doc__.replace(
@@ -107,3 +120,5 @@ svg2pdf.__doc__ = surface.Surface.convert.__doc__.replace(
     'the format for this class', 'PDF')
 svg2ps.__doc__ = surface.Surface.convert.__doc__.replace(
     'the format for this class', 'PS')
+svg2eps.__doc__ = surface.Surface.convert.__doc__.replace(
+    'the format for this class', 'EPS')

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -114,7 +114,7 @@ class Surface(object):
                 background_color=None, negate_colors=False,
                 invert_images=False, write_to=None, output_width=None,
                 output_height=None, **kwargs):
-        """Convert a SVG document to the format for this class.
+        """Convert an SVG document to the format for this class.
 
         Specify the input by passing one of these:
 

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -508,6 +508,16 @@ class PSSurface(Surface):
     surface_class = cairo.PSSurface
 
 
+class EPSSurface(Surface):
+    """A surface that writes in Encapsulated PostScript format."""
+
+    def _create_surface(self, width, height):
+        """Create and return ``(cairo_surface, width, height)``."""
+        cairo_surface = cairo.PSSurface(self.output, width, height)
+        cairo_surface.set_eps(True)
+        return cairo_surface, width, height
+
+
 class PNGSurface(Surface):
     """A surface that writes in PNG format."""
     device_units_per_user_units = 1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ CairoSVG - A Simple SVG Converter Based on Cairo
 ================================================
 
 CairoSVG is an SVG converter based on Cairo. It can convert SVG files to PDF,
-PostScript and PNG files.
+EPS, PS, and PNG files.
 
 For further information, please visit the `CairoSVG Website
 <http://cairosvg.org/>`_.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 CairoSVG - A Simple SVG Converter Based on Cairo
 ================================================
 
-CairoSVG is a SVG converter based on Cairo. It can convert SVG files to PDF,
+CairoSVG is an SVG converter based on Cairo. It can convert SVG files to PDF,
 PostScript and PNG files.
 
 For further information, please visit the `CairoSVG Website


### PR DESCRIPTION
Added the ability to convert to encapsulated postscript (EPS) in addition to ordinary postscript, as described in Issue #294. The main difference is a new `svg2eps` function and an `EPSSurface` class which, following the pattern of `PNGSurface`, overrides the default `_create_surface()` method. In order to create an EPS surface, we simply create an ordinary `PSSurface`, and then call `set_eps(True)` as documented here: https://cairocffi.readthedocs.io/en/latest/api.html?highlight=set_eps#cairocffi.PSSurface.set_eps