### PR TITLE
Adding error message for unexpected root tag.

### DIFF
--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -125,6 +125,10 @@ def preserve_ratio(surface, node, width=None, height=None):
         width = width or node_width
         height = height or node_height
         viewbox_width, viewbox_height = node.image_width, node.image_height
+    else:
+        raise TypeError(
+            ('Root node is {}. Should be one of '
+             'marker, svg, image, or g.').format(node.tag))
 
     translate_x = 0
     translate_y = 0


### PR DESCRIPTION
If root tag is unexpected in svg (say, 'html', which can occasionally be
encountered), the error is previously somewhat cryptic; this commit
offers an explicit message.