### PR TITLE
Fix marker positions for unclosed paths

### DIFF
--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -306,12 +306,16 @@ def path(surface, node):
         elif letter == 'm':
             # Current point relative move
             x, y, string = point(surface, string)
+            if last_letter and last_letter not in 'zZ':
+                node.vertices.append(None)
             surface.context.rel_move_to(x, y)
             current_point = current_point[0] + x, current_point[1] + y
 
         elif letter == 'M':
             # Current point move
             x, y, string = point(surface, string)
+            if last_letter and last_letter not in 'zZ':
+                node.vertices.append(None)
             surface.context.move_to(x, y)
             current_point = x, y
 


### PR DESCRIPTION
TLDR: coordinates and angles in the array used to render markers get out of sync after an unclosed sub-path.

In path.py, `node.vertices` keeps track of the vertices of the path being parsed, and consists of alternating pairs of (x,y) coordinates and outgoing and incoming angles. The list is used by the draw_markers() function in the same file, which pops items off it two at a time to get the current point and a pair of angles.

When path() encounters a `z` ([closepath](https://www.w3.org/Graphics/SVG/1.1/paths.html#PathDataClosePathCommand)) command, `None` is appended to the list in place of a pair of angles to mark the end of a sub-path, with the following `M` or `m` (moveto) adding the starting point of a new sub-path. If an `M` or `m` is used without a preceding `z`, however, only the new starting point is appended, resulting in two consecutive pairs of coordinates in the array. This break of parity causes draw_markers() to interpret angles as coordinates and vice versa for the remainder of the path (hence drawing the markers for the bottom sub-path near the origin in the top left in the attached image). The changed file adds a `None` to the array if an `M` or `m` is not preceded by a `z`.

There are more discrepancies between CairoSVG's behaviour for markers and [the SVG specification](https://www.w3.org/Graphics/SVG/1.1/painting.html#Markers) visible in the image that I haven't looked into: start/end markers are placed at the ends of every sub-path instead of only the first and last nodes overall, and some of the angles are off. This is an easy fix for the positions of the markers, though. My encounter with the bug was not related to markers in the first place, but involved using every other element of `node.vertices` to get the vertices of a path from a string.

A similar problem might still occur if a `z` is followed by a command other than `M`/`m`, which, though valid SVG, I don't remember having ever seen in an SVG file.

![](https://user-images.githubusercontent.com/72402381/99915510-6acef800-2d04-11eb-9e0a-9704aa30a798.png)

The input SVG:
```xml
<?xml version="1.0" encoding="utf-8"?>
<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600">
<defs>
<marker id="te" viewBox="0 0 10 10" refX="1" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto"><path d="M0,0 10,5 0,10z"/></marker>
<marker id="tm" viewBox="0 0 10 10" refX="5" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto"><path d="M0,5 5,0 10,5 5,10z"/></marker>
<marker id="ts" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto"><path d="M10,0 0,5 10,10z"/></marker>
</defs>
<rect width="600" height="600" fill="#fff"/>
<path d="M100,100A300,300 0 0,1 300,300A200,200 0 0,1 200,200zM300,100A300,300 0 0,1 500,300A200,200 0 0,1 400,200M100,300A300,300 0 0,1 300,500A200,200 0 0,1 200,400" fill="none" stroke="#000" stroke-width="10" marker-start="url(#ts)" marker-mid="url(#tm)" marker-end="url(#te)"/>
</svg>
```