### PR TITLE
More marker fixes

### DIFF
--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -153,6 +153,20 @@ def preserve_ratio(surface, node, width=None, height=None):
     return scale_x, scale_y, translate_x, translate_y
 
 
+def bezier_angles(*points):
+    """Return the tangent angles of a Bezier curve of any degree."""
+    if len(points) < 2:
+        # zero-length segment
+        return (0, 0)
+    # Control points that coincide with vertices can be removed
+    elif points[0] == points[1]:
+        return bezier_angles(*points[1:])
+    elif points[-2] == points[-1]:
+        return bezier_angles(*points[:-1])
+    else:
+        return (point_angle(*points[0], *points[1]), point_angle(*points[-2], *points[-1]))
+
+
 def clip_marker_box(surface, node, scale_x, scale_y):
     """Get the clip ``(x, y, width, height)`` of the marker box."""
     width = size(surface, node.get('markerWidth', '3'), 'x')

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -3,7 +3,7 @@ Paths manager.
 
 """
 
-from math import pi, radians, cos, sin
+from math import pi, radians, cos, sin, atan2
 
 from .bounding_box import calculate_bounding_box
 from .helpers import (
@@ -228,8 +228,12 @@ def path(surface, node):
             angle2 = point_angle(xc, yc, xe, ye)
 
             # Store the tangent angles
-            radius_to_tangent = pi/2 if sweep else -pi/2
-            node.vertices.append((angle1 + radius_to_tangent, angle2 + radius_to_tangent))
+            tangent1 = angle1 + (pi/2 if sweep else -pi/2)
+            tangent2 = angle2 + (pi/2 if sweep else -pi/2)
+            if radii_ratio != 1:
+                tangent1 = atan2(radii_ratio*sin(tangent1), cos(tangent1))
+                tangent2 = atan2(radii_ratio*sin(tangent2), cos(tangent2))
+            node.vertices.append((tangent1 + rotation, tangent2 + rotation))
 
             # Draw the arc
             surface.context.save()

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -210,7 +210,7 @@ def path(surface, node):
                     next_letter = '{} '.format(letter)
                 else:
                     next_letter = ''
-                string = 'l {} {} {}{}'.format(x3, y3, next_letter, string)                continue
+                string = 'l {} {} {}{}'.format(x3, y3, next_letter, string)
                 continue
 
             radii_ratio = ry / rx

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -81,21 +81,17 @@ def draw_markers(surface, node):
                     clip_box = clip_marker_box(
                         surface, marker_node, scale_x, scale_y)
                 else:
-                    # Calculate sizes
+                    # Calculate sizes and position
                     marker_width = size(surface,
                                         marker_node.get('markerWidth', '3'), 'x')
                     marker_height = size(surface,
                                          marker_node.get('markerHeight', '3'), 'y')
-                    bounding_box = calculate_bounding_box(surface, marker_node)
 
-                    # Calculate position and scale (preserve aspect ratio)
                     translate_x = -size(surface, marker_node.get('refX', '0'), 'x')
                     translate_y = -size(surface, marker_node.get('refY', '0'), 'y')
-                    scale_x = scale_y = min(
-                        marker_width / bounding_box[2],
-                        marker_height / bounding_box[3])
 
-                    # No clipping since viewbox is not present
+                    # No clipping or scaling since viewbox is not present
+                    scale_x = scale_y = 1
                     clip_box = None
 
                 # Add extra path for marker

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -7,8 +7,8 @@ from math import pi, radians, cos, sin
 
 from .bounding_box import calculate_bounding_box
 from .helpers import (
-    PATH_LETTERS, clip_marker_box, node_format, normalize, point, point_angle,
-    preserve_ratio, quadratic_points, rotate, size)
+    PATH_LETTERS, bezier_angles, clip_marker_box, node_format, normalize,
+    point, point_angle, preserve_ratio, quadratic_points, rotate, size)
 from .url import parse_url
 
 
@@ -246,7 +246,7 @@ def path(surface, node):
             x1, y1, string = point(surface, string)
             x2, y2, string = point(surface, string)
             x3, y3, string = point(surface, string)
-            node.vertices.append((point_angle(0, 0, x1, y1), point_angle(x2, y2, x3, y3)))
+            node.vertices.append(bezier_angles((0, 0), (x1, y1), (x2, y2), (x3, y3)))
             surface.context.rel_curve_to(x1, y1, x2, y2, x3, y3)
             current_point = current_point[0] + x3, current_point[1] + y3
 
@@ -264,7 +264,7 @@ def path(surface, node):
             x1, y1, string = point(surface, string)
             x2, y2, string = point(surface, string)
             x3, y3, string = point(surface, string)
-            node.vertices.append((point_angle(x, y, x1, y1), point_angle(x2, y2, x3, y3)))
+            node.vertices.append(bezier_angles((x, y), (x1, y1), (x2, y2), (x3, y3)))
             surface.context.curve_to(x1, y1, x2, y2, x3, y3)
             current_point = x3, y3
 
@@ -328,7 +328,7 @@ def path(surface, node):
             x2, y2, string = point(surface, string)
             xq1, yq1, xq2, yq2, xq3, yq3 = quadratic_points(0, 0, x1, y1, x2, y2)
             surface.context.rel_curve_to(xq1, yq1, xq2, yq2, xq3, yq3)
-            node.vertices.append((point_angle(0, 0, x1, y1), point_angle(x1, y1, x2, y2)))
+            node.vertices.append(bezier_angles((0, 0), (x1, y1), (x2, y2)))
             current_point = x + x2, y + y2
 
             # Save absolute values for x and y, useful if next letter is t or T
@@ -344,7 +344,7 @@ def path(surface, node):
             x2, y2, string = point(surface, string)
             xq1, yq1, xq2, yq2, xq3, yq3 = quadratic_points(x, y, x1, y1, x2, y2)
             surface.context.curve_to(xq1, yq1, xq2, yq2, xq3, yq3)
-            node.vertices.append((point_angle(x, y, x1, y1), point_angle(x1, y1, x2, y2)))
+            node.vertices.append(bezier_angles((x, y), (x1, y1), (x2, y2)))
             current_point = x2, y2
 
         elif letter == 's':
@@ -354,7 +354,7 @@ def path(surface, node):
             y1 = y - y2 if last_letter in 'csCS' else 0
             x2, y2, string = point(surface, string)
             x3, y3, string = point(surface, string)
-            node.vertices.append((point_angle(0, 0, x1, y1), point_angle(x2, y2, x3, y3)))
+            node.vertices.append(bezier_angles((0, 0), (x1, y1), (x2, y2), (x3, y3)))
             surface.context.rel_curve_to(x1, y1, x2, y2, x3, y3)
             current_point = x + x3, y + y3
 
@@ -373,7 +373,7 @@ def path(surface, node):
             y1 = y + (y - y2) if last_letter in 'csCS' else y
             x2, y2, string = point(surface, string)
             x3, y3, string = point(surface, string)
-            node.vertices.append((point_angle(x, y, x1, y1), point_angle(x2, y2, x3, y3)))
+            node.vertices.append(bezier_angles((x, y), (x1, y1), (x2, y2), (x3, y3)))
             surface.context.curve_to(x1, y1, x2, y2, x3, y3)
             current_point = x3, y3
 
@@ -384,7 +384,7 @@ def path(surface, node):
             y1 = y - y1 if last_letter in 'qtQT' else 0
             x2, y2, string = point(surface, string)
             xq1, yq1, xq2, yq2, xq3, yq3 = quadratic_points(0, 0, x1, y1, x2, y2)
-            node.vertices.append((point_angle(0, 0, x1, y1), point_angle(x1, y1, x2, y2)))
+            node.vertices.append(bezier_angles((0, 0), (x1, y1), (x2, y2)))
             surface.context.rel_curve_to(xq1, yq1, xq2, yq2, xq3, yq3)
             current_point = x + x2, y + y2
 
@@ -401,7 +401,7 @@ def path(surface, node):
             y1 = y + (y - y1) if last_letter in 'qtQT' else y
             x2, y2, string = point(surface, string)
             xq1, yq1, xq2, yq2, xq3, yq3 = quadratic_points(x, y, x1, y1, x2, y2)
-            node.vertices.append((point_angle(x, y, x1, y1), point_angle(x1, y1, x2, y2)))
+            node.vertices.append(bezier_angles((x, y), (x1, y1), (x2, y2)))
             surface.context.curve_to(xq1, yq1, xq2, yq2, xq3, yq3)
             current_point = x2, y2
 

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -3,7 +3,7 @@ Paths manager.
 
 """
 
-from math import pi, radians
+from math import pi, radians, cos, sin
 
 from .bounding_box import calculate_bounding_box
 from .helpers import (
@@ -34,11 +34,13 @@ def draw_markers(surface, node):
         point = node.vertices.pop(0)
         angles = node.vertices.pop(0) if node.vertices else None
         if angles:
+            angle1 = angles[0]
             if position == 'start':
-                angle = pi + angles[0]
+                angle = angle1
             else:
-                angle = (angle2 + pi + angles[0]) / 2
-            angle1, angle2 = angles
+                # Bisect the angle difference by summing the corresponding unit vectors
+                angle = point_angle(0, 0, cos(angle1) + cos(angle2), sin(angle1) + sin(angle2))
+            angle2 = angles[1]
         else:
             angle = angle2
             position = 'end'

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -203,7 +203,14 @@ def path(surface, node):
 
             # rx=0 or ry=0 means straight line
             if not rx or not ry:
-                string = 'l {} {} {}'.format(x3, y3, string)
+                if string and string[0] not in PATH_LETTERS:
+                    # As we replace the current operation by l, we must be sure
+                    # that the next letter is set to the real current letter (a
+                    # or A) in case it’s omitted
+                    next_letter = '{} '.format(letter)
+                else:
+                    next_letter = ''
+                string = 'l {} {} {}{}'.format(x3, y3, next_letter, string)                continue
                 continue
 
             radii_ratio = ry / rx

--- a/cairosvg/path.py
+++ b/cairosvg/path.py
@@ -31,13 +31,17 @@ def draw_markers(surface, node):
     while node.vertices:
         subpath = node.vertices.pop(0)
         angle1, angle2 = None, None
+
+        if len(subpath) % 2 == 0:
+            # Closed subpath: assign final angle to average with initial angle &
+            # append copy of first vertex and angle at the end
+            angle2 = subpath[-1][1]
+            subpath += subpath[:2]
+
         while subpath:
             # Calculate position and angle
             point = subpath.pop(0)
             angles = subpath.pop(0) if subpath else None
-            if angle2 is None and len(subpath) % 2 == 0:
-                # Start of closed subpath: average angles of first and last segment
-                angle2 = subpath[-1][1]
 
             if angles:
                 angle1 = angles[0]


### PR DESCRIPTION
Following on from [my previous PR](https://github.com/Kozea/CairoSVG/pull/302), I've been working on-and-off on getting the orientation of markers correct, as well as fixing some of their types and sizes. As this is a bigger change than I anticipated, [I've made a set of testcases](https://github.com/SilverCardioid/CairoSVG/tree/main/sahara/node_vertices_tests#readme) to compare the results of the current repo and my fork on a few test SVGs (the before-and-afters being 'Kozea' and 'AgC/master' in the middle column).

A possible breaking change: instead of different sub-paths being separated by a `None` in `node.vertices`, the sub-paths are now in nested lists within the array. A new sub-list is added to `vertices` for every `M` or `m`, and coordinates and angles are appended to the last sub-list instead of the main array. This makes it easier for draw_markers() to handle the difference between closed and unclosed sub-paths, as the former should take the angle of the closing segment into account. I'm hoping the array isn't used in other places (within the library or elsewhere) in a way that would be broken by this change.

The diff within the draw_markers() function may not seem that useful, since the main loop has been indented an additional level and the GitHub interface doesn't seem to have the option to ignore whitespace differences like some other tools do. The only parts that have changed there are the determination of the position and angle (lines 32–61 and 131 in the new file), and the [size calculation](https://github.com/SilverCardioid/CairoSVG/commit/0835fc88780de1272eeb9181a02986d4289146cc) at lines 84–95.