### PR TITLE
fix method svg2pdf error "cannot write mode CMYK as PNG" when image mode is P

### DIFF
--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -79,7 +79,8 @@ def image(surface, node):
 
         if surface.map_image:
             image = surface.map_image(image)
-
+        if image.mode == "P":
+            image = image.convert("RGB")
         image.save(png_file, 'PNG')
         png_file.seek(0)
 


### PR DESCRIPTION
fix method svg2pdf error "cannot write mode CMYK as PNG" when image mode is P