### PR TITLE
Assume that 'ch' is 0.5em wide.

### DIFF
--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -378,6 +378,9 @@ def size(surface, string, reference='xy'):
     elif string.endswith('ex'):
         # Assume that 1em == 2ex
         return surface.font_size * float(string[:-2]) / 2
+    elif string.endswith('ch'):
+        # A '0' must be assumed to be 0.5em wide.
+        return surface.font_size * float(string[:-2]) / 2
 
     for unit, coefficient in UNITS.items():
         if string.endswith(unit):


### PR DESCRIPTION
W3 mandates this behavior as the fallback assumption.
https://www.w3.org/TR/css-values-3/#font-relative-lengths

> In the cases where it is impossible or impractical to determine the
> measure of the "0" glyph, it must be assumed to be 0.5em wide by 1em
> tall. Thus, the ch unit falls back to 0.5em in the general case, and
> to 1em when it would be typeset upright (i.e. writing-mode is
> vertical-rl or vertical-lr and text-orientation is upright).

I'm happy to add a test for this, but would you mind offering a suggestion as to where it should go?  I had edited one into `test_non_regression/svg/coords-units-03-b.svg` as the place where it looked like other units were being tested, but then I realized that's an official SVG 1.1 test.  I don't see a 3rd edition test suite, and the SVG 1.2 suite doesn't appear to have a test for `ch` either.  I don't see any other coords test that handles units so I'm not sure what the best way to proceed is.

---

As the motivating example, there's an SVG that I made which uses `ch` for all of its x-coordinates so that I can make lines align with text:

![ophistory_all](https://user-images.githubusercontent.com/335281/184281770-c6a77835-0128-42ac-92d1-a8fe9188732a.svg)

This appears fine, as your webbrowser likely understands how to render `ch` units.

Currently, trying to render this svg with CairoSVG results in:

```
Traceback (most recent call last):
  File "/home/miller/ws/ophistory/examples/../ophistory.py", line 356, in <module>
    main(sys.argv)
  File "/home/miller/ws/ophistory/examples/../ophistory.py", line 352, in main
    svg2png(bytestring=svg,write_to=args.output)
  File "/home/miller/.local/lib/python3.10/site-packages/cairosvg/__init__.py", line 55, in svg2png
    return surface.PNGSurface.convert(
  File "/home/miller/.local/lib/python3.10/site-packages/cairosvg/surface.py", line 131, in convert
    instance = cls(
  File "/home/miller/.local/lib/python3.10/site-packages/cairosvg/surface.py", line 207, in __init__
    raise ValueError('The SVG size is undefined')
ValueError: The SVG size is undefined
```

After this change, it renders like:

![ophistory_all cairosvg](https://user-images.githubusercontent.com/335281/184281941-650a8be9-a766-4daa-9dba-8f04c9f6b64f.png)

