### PR TITLE
getdefaultlocale -> getlocale

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: 
-          - "3.6"
+        python-version:
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +32,7 @@ jobs:
       - name: Install tests’ requirements
         run: python -m pip install .[test] pytest-xdist
       - name: Launch tests
-        run: python -m pytest -n auto
+        run: python -m pytest -n auto -W error
       - name: Check coding style
         run: python -m flake8
       - name: Check imports order

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tests’ requirements
         run: python -m pip install .[test] pytest-xdist
       - name: Launch tests
-        run: python -m pytest -n auto -W error
+        run: python -m pytest -n auto
       - name: Check coding style
         run: python -m flake8
       - name: Check imports order

--- a/cairosvg/features.py
+++ b/cairosvg/features.py
@@ -6,7 +6,7 @@ Helpers related to SVG conditional processing.
 import locale
 
 ROOT = 'http://www.w3.org/TR/SVG11/feature'
-LOCALE = locale.getdefaultlocale()[0] or ''
+LOCALE = locale.getlocale()[0] or ''
 SUPPORTED_FEATURES = frozenset((
     ROOT + '#' + feature for feature in (
         'SVG',


### PR DESCRIPTION
locale.getdefaultlocale has started to give a DeprecationWarning in Python 3.11.

As far as I can cell, locale.getlocale should be used instead

This warning is (for example) causing these tests to fail: https://github.com/mscroggs/symfem/actions/runs/3657916856/jobs/6182054650