### PR TITLE
Use pathlib

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -3,7 +3,6 @@ CairoSVG - A simple SVG converter based on Cairo.
 
 """
 
-import os
 import sys
 from pathlib import Path
 
@@ -15,9 +14,9 @@ if hasattr(sys, 'frozen'):
     else:
         # Frozen with something else (py2exe, etc.)
         # See https://github.com/Kozea/WeasyPrint/pull/269
-        ROOT = Path(os.path.dirname(sys.executable))
+        ROOT = Path(sys.executable).parent
 else:
-    ROOT = Path(os.path.dirname(__file__))
+    ROOT = Path(__file__).resolve().parent
 
 VERSION = __version__ = (ROOT / 'VERSION').read_text().strip()
 

--- a/cairosvg/__main__.py
+++ b/cairosvg/__main__.py
@@ -4,8 +4,8 @@ Command-line interface to CairoSVG.
 """
 
 import argparse
-import os
 import sys
+from pathlib import Path
 
 from . import SURFACES, VERSION
 
@@ -72,7 +72,7 @@ def main(argv=None, stdout=None, stdin=None):
         kwargs['url'] = options.input
     output_format = (
         options.format or
-        os.path.splitext(options.output)[1].lstrip('.') or
+        Path(options.output).suffix.lstrip('.') or
         'pdf').upper()
 
     SURFACES[output_format.upper()].convert(**kwargs)

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -3,7 +3,7 @@ Utils dealing with URLs.
 
 """
 
-import os.path
+import os
 import re
 from pathlib import Path
 from urllib.parse import urljoin, urlparse


### PR DESCRIPTION
Use `pathlib.Path` for path operations where possible. The test methods are then calling the code with strings, so it would be nice to make the code working for `os.PathLike` in general.