### PR TITLE
Fixed ValueError: could not convert string to float: ''

### DIFF
--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -5,6 +5,7 @@ Surface helpers.
 
 import re
 from math import atan2, cos, hypot, radians, sin, tan
+import warning
 
 from .surface import cairo
 from .url import parse_url
@@ -385,8 +386,9 @@ def size(surface, string, reference='xy'):
         if string.endswith(unit):
             try:
                 number = float(string[:-len(unit)])
-            except (ValueError, TypeError, IndexError) as e:
+            except ValueError:
                 number = 0.0
+                warnings.warn("Numeric value is invalid. Value is set to 0")
             return number * (surface.dpi * coefficient if coefficient else 1)
 
     # Unknown size

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -383,7 +383,10 @@ def size(surface, string, reference='xy'):
 
     for unit, coefficient in UNITS.items():
         if string.endswith(unit):
-            number = float(string[:-len(unit)])
+            try:
+                number = float(string[:-len(unit)])
+            except Exception as e:
+                number = 0.0
             return number * (surface.dpi * coefficient if coefficient else 1)
 
     # Unknown size

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -386,6 +386,7 @@ def size(surface, string, reference='xy'):
             try:
                 number = float(string[:-len(unit)])
             except Exception as e:
+                print(f"{string=}")
                 number = 0.0
             return number * (surface.dpi * coefficient if coefficient else 1)
 

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -387,8 +387,8 @@ def size(surface, string, reference='xy'):
             try:
                 number = float(string[:-len(unit)])
             except ValueError:
-                number = 0.0
                 warnings.warn("Numeric value is invalid. Value is set to 0")
+                return 0
             return number * (surface.dpi * coefficient if coefficient else 1)
 
     # Unknown size

--- a/cairosvg/helpers.py
+++ b/cairosvg/helpers.py
@@ -385,8 +385,7 @@ def size(surface, string, reference='xy'):
         if string.endswith(unit):
             try:
                 number = float(string[:-len(unit)])
-            except Exception as e:
-                print(f"{string=}")
+            except (ValueError, TypeError, IndexError) as e:
                 number = 0.0
             return number * (surface.dpi * coefficient if coefficient else 1)
 


### PR DESCRIPTION
I`ve fixed https://github.com/Kozea/CairoSVG/issues/423
My svgs were broken. They used transform="translate(0,px)" things (CairoSVG was trying to get float from text "px").
So I just set number as 0.0 in case exceptions.