### PR TITLE
Update to allow multipage output.

### DIFF
--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -242,11 +242,15 @@ class Surface(object):
                 raise ValueError("Cannot provide a surface as an output unless it is multipage.")
             self.cairo = output.cairo
             self.output = output.output
-            self.width = width * self.device_units_per_user_units
-            self.height = height * self.device_units_per_user_units
+            self.width = output.width
+            self.height = output.height
             # Add new page for this conversion
             if not output.first_page:
                 self.cairo.show_page()
+            if isinstance(self.cairo, cairo.surfaces.PDFSurface):
+                self.width = width * self.device_units_per_user_units
+                self.height = height * self.device_units_per_user_units
+                self.cairo.set_size(self.width, self.height)
             output.first_page = False
         else:
             # Actual surface dimensions: may be rounded on raster surfaces types

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -122,8 +122,8 @@ class Surface(object):
         Specifiy the output with:
 
         :param write_to: The filename of file-like object where to write the
-                         output or MultipageSurface to write to. If None or not
-                         provided, return a byte string.
+                         output or a ```Surface``` created with `multi_page` set to
+                         True. If None or not provided, return a byte string.
 
         Only ``bytestring`` can be passed as a positional argument, other
         parameters are keyword-only.


### PR DESCRIPTION
Existing code will work as is, but now calling code can pass a list of content instead of a single value and get a multipage output file (assuming the Cairo backend supports it).