### PR TITLE
Ensure bytestring is bytes before checking for gzip header

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -387,6 +387,8 @@ class Tree(Node):
             if not bytestring:
                 bytestring = self.fetch_url(
                     parse_url(self.url), 'image/svg+xml')
+            if isinstance(bytestring, str):
+                bytestring = bytestring.encode('utf-8')
             if bytestring.startswith(b'\x1f\x8b'):
                 bytestring = gzip.decompress(bytestring)
             tree = ElementTree.fromstring(


### PR DESCRIPTION
Fixes a TypeError when checking if input is gzipped using `bytestring.startswith(b"\x1f\x8b")`.


```bash
File ".../site-packages/cairosvg/parser.py", line 447, in __init__
    if bytestring.startswith(b"\x1f\x8b"):
TypeError: startswith first arg must be str or a tuple of str, not bytes
```

This patch ensures `bytestring` is properly encoded as `bytes` before gzip header detection.