### PR TITLE
Fix re.sub positional argument in nt_compatible_path

### DIFF
--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -69,7 +69,7 @@ def nt_compatible_path(path):
     """
     if os.name == 'nt' and re.match(
             '^/[a-z]:/', path, re.IGNORECASE | re.MULTILINE | re.DOTALL):
-        return re.sub('^/', '', path, re.IGNORECASE | re.MULTILINE | re.DOTALL)
+        return re.sub('^/', '', path, count=1, flags=re.IGNORECASE | re.MULTILINE | re.DOTALL)
     else:
         return path
 


### PR DESCRIPTION
## Summary

In `nt_compatible_path()` (`cairosvg/url.py`, line 72), the combined flags `re.IGNORECASE | re.MULTILINE | re.DOTALL` (= 26) are passed as the 4th positional argument to `re.sub()`, which is `count`, not `flags`.

**Before:**
```python
return re.sub('^/', '', path, re.IGNORECASE | re.MULTILINE | re.DOTALL)
# interpreted as: re.sub(pattern, repl, string, count=26)
```

**After:**
```python
return re.sub('^/', '', path, count=1, flags=re.IGNORECASE | re.MULTILINE | re.DOTALL)
```