### PR TITLE
feat(url): accept path-like objects for the url parameter

### DIFF
--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -4,6 +4,7 @@ SVG Parser.
 """
 
 import gzip
+import os
 import re
 from urllib.parse import urlunparse
 from xml.etree.ElementTree import Element
@@ -345,6 +346,8 @@ class Tree(Node):
         bytestring = kwargs.get('bytestring')
         file_obj = kwargs.get('file_obj')
         url = kwargs.get('url')
+        if isinstance(url, os.PathLike):
+            url = os.fspath(url)
         unsafe = kwargs.get('unsafe')
         parent = kwargs.get('parent')
         parent_children = kwargs.get('parent_children')

--- a/cairosvg/surface.py
+++ b/cairosvg/surface.py
@@ -105,7 +105,7 @@ class Surface(object):
 
         :param bytestring: The SVG source as a byte-string.
         :param file_obj: A file-like object.
-        :param url: A filename.
+        :param url: A filename, given as a string or a path-like object.
 
         Give some options:
 

--- a/cairosvg/test_api.py
+++ b/cairosvg/test_api.py
@@ -69,6 +69,9 @@ def test_api(tmp_path):
     assert svg2png(url=str(temp_0)) == expected_content
     assert svg2png(url=f'file://{temp_0}') == expected_content
 
+    # Read from a pathlib.Path
+    assert svg2png(url=temp_0) == expected_content
+
     with temp_0.open('rb') as file_object:
         # Read from a real file object
         assert svg2png(file_obj=file_object) == expected_content

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -104,6 +104,8 @@ def parse_url(url, base=None):
     the "folder" part of it is prepended to the URL.
 
     """
+    if isinstance(url, os.PathLike):
+        url = os.fspath(url)
     if url:
         match = URL.search(url)
         if match:


### PR DESCRIPTION
Closes #429. The `url` parameter now accepts `pathlib.Path` and other `os.PathLike` objects in addition to strings, as confirmed wanted by a maintainer in the issue thread. Path-like values are normalized with `os.fspath` so existing string behavior is unchanged.